### PR TITLE
International

### DIFF
--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -1,4 +1,3 @@
-import string
 import re
 import sys
 import csv
@@ -13,11 +12,10 @@ from orderedset import OrderedSet
 from flask import current_app
 
 from . import EMAIL_REGEX_PATTERN, hostname_part, tld_part
-from notifications_utils.formatters import strip_and_remove_obscure_whitespace, strip_whitespace, OBSCURE_WHITESPACE
+from notifications_utils.formatters import strip_and_remove_obscure_whitespace, strip_whitespace
 from notifications_utils.template import Template
 from notifications_utils.columns import Columns, Row, Cell
 from notifications_utils.international_billing_rates import (
-    COUNTRY_PREFIXES,
     INTERNATIONAL_BILLING_RATES,
 )
 
@@ -345,7 +343,11 @@ def normalise_phone_number(number):
 
 
 def is_local_phone_number(number):
-    return (not parse_number(number, region_code) == False)
+    if parse_number(number, region_code) is False:
+        return False
+    else:
+        return True
+
 
 international_phone_info = namedtuple('PhoneNumber', [
     'international',
@@ -390,7 +392,7 @@ def validate_phone_number(number, column=None, international=False):
 
     number = normalise_phone_number(number)
 
-    if number == False:
+    if number is False:
         raise InvalidPhoneError('Not a valid international number')
 
     if len(number) < 8:
@@ -502,7 +504,7 @@ def format_phone_number_human_readable(phone_number):
         return phonenumbers.format_number(match.number, phonenumbers.PhoneNumberFormat.INTERNATIONAL)
 
     return phone_number
-    
+
 
 def allowed_to_send_to(recipient, whitelist):
     return format_recipient(recipient) in [
@@ -519,17 +521,18 @@ def insert_or_append_to_dict(dict_, key, value):
     else:
         dict_.update({key: value})
 
+
 def parse_number(number, region=None):
     matches = []
     for match in phonenumbers.PhoneNumberMatcher(number, region):
         matches.append(match)
 
     if len(matches) > 0:
-        if region != None:
+        if region is not None:
             if matches[0].number.country_code == int(country_code):
                 return matches[0]
             else:
-                return False 
+                return False
         return matches[0]
     else:
         return False

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -3,6 +3,7 @@ import re
 import sys
 import csv
 import phonenumbers
+import os
 from contextlib import suppress
 from functools import lru_cache, partial
 from itertools import islice
@@ -21,7 +22,8 @@ from notifications_utils.international_billing_rates import (
 )
 
 
-uk_prefix = '44'
+country_code = os.getenv("PHONE_COUNTRY_CODE", "1")
+region_code = os.getenv("PHONE_REGION_CODE", "US")
 
 first_column_headings = {
     'email': ['email address'],
@@ -334,35 +336,16 @@ class InvalidAddressError(InvalidEmailError):
 
 
 def normalise_phone_number(number):
+    match = parse_number(number, region_code) or parse_number(number)
 
-    for character in string.whitespace + OBSCURE_WHITESPACE + '()-+':
-        number = number.replace(character, '')
-
-    try:
-        list(map(int, number))
-    except ValueError:
-        raise InvalidPhoneError('Must not contain letters or symbols')
-
-    return number.lstrip('0')
-
-
-def is_uk_phone_number(number):
-
-    if (
-        (number.startswith('0') and not number.startswith('00'))
-    ):
-        return True
-
-    number = normalise_phone_number(number)
-
-    if (
-        number.startswith(uk_prefix) or
-        (number.startswith('7') and len(number) < 11)
-    ):
-        return True
+    if match:
+        return phonenumbers.format_number(match.number, phonenumbers.PhoneNumberFormat.E164)
 
     return False
 
+
+def is_local_phone_number(number):
+    return (not parse_number(number, region_code) == False)
 
 international_phone_info = namedtuple('PhoneNumber', [
     'international',
@@ -377,45 +360,38 @@ def get_international_phone_info(number):
     prefix = get_international_prefix(number)
 
     return international_phone_info(
-        international=(prefix != uk_prefix),
+        international=(prefix != country_code),
         country_prefix=prefix,
         billable_units=get_billable_units_for_prefix(prefix)
     )
 
 
 def get_international_prefix(number):
-    return next(
-        (prefix for prefix in COUNTRY_PREFIXES if number.startswith(prefix)),
-        None
-    )
+    number = phonenumbers.parse(number, None)
+    return str(number.country_code)
 
 
 def get_billable_units_for_prefix(prefix):
     return INTERNATIONAL_BILLING_RATES[prefix]['billable_units']
 
 
-def validate_uk_phone_number(number, column=None):
-
-    number = normalise_phone_number(number).lstrip(uk_prefix).lstrip('0')
-
-    if not number.startswith('7'):
-        raise InvalidPhoneError('Not a UK mobile number')
-
-    if len(number) > 10:
-        raise InvalidPhoneError('Too many digits')
-
-    if len(number) < 10:
-        raise InvalidPhoneError('Not enough digits')
-
-    return '{}{}'.format(uk_prefix, number)
+def validate_local_phone_number(number, column=None):
+    match = parse_number(number, region_code)
+    if match:
+        return phonenumbers.format_number(match.number, phonenumbers.PhoneNumberFormat.E164)
+    else:
+        raise InvalidPhoneError('Not a valid local number')
 
 
 def validate_phone_number(number, column=None, international=False):
 
-    if (not international) or is_uk_phone_number(number):
-        return validate_uk_phone_number(number)
+    if (not international) or is_local_phone_number(number):
+        return validate_local_phone_number(number)
 
     number = normalise_phone_number(number)
+
+    if number == False:
+        raise InvalidPhoneError('Not a valid international number')
 
     if len(number) < 8:
         raise InvalidPhoneError('Not enough digits')
@@ -520,22 +496,13 @@ def format_recipient(recipient):
 
 
 def format_phone_number_human_readable(phone_number):
-    try:
-        phone_number = validate_phone_number(phone_number, international=True)
-    except InvalidPhoneError:
-        # if there was a validation error, we want to shortcut out here, but still display the number on the front end
-        return phone_number
-    international_phone_info = get_international_phone_info(phone_number)
+    match = parse_number(phone_number, region_code) or parse_number(phone_number)
 
-    return phonenumbers.format_number(
-        phonenumbers.parse('+' + phone_number, None),
-        (
-            phonenumbers.PhoneNumberFormat.INTERNATIONAL
-            if international_phone_info.international
-            else phonenumbers.PhoneNumberFormat.NATIONAL
-        )
-    )
+    if match:
+        return phonenumbers.format_number(match.number, phonenumbers.PhoneNumberFormat.INTERNATIONAL)
 
+    return phone_number
+    
 
 def allowed_to_send_to(recipient, whitelist):
     return format_recipient(recipient) in [
@@ -551,3 +518,18 @@ def insert_or_append_to_dict(dict_, key, value):
             dict_[key] = [dict_[key], value]
     else:
         dict_.update({key: value})
+
+def parse_number(number, region=None):
+    matches = []
+    for match in phonenumbers.PhoneNumberMatcher(number, region):
+        matches.append(match)
+
+    if len(matches) > 0:
+        if region != None:
+            if matches[0].number.country_code == int(country_code):
+                return matches[0]
+            else:
+                return False 
+        return matches[0]
+    else:
+        return False

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '34.0.5'
+__version__ = '34.0.6'
 # GDS version '33.2.1'

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+phonenumbers==8.10.13
 pytest==5.0.0
 pytest-mock==1.10.4
 pytest-cov==2.7.1

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -29,25 +29,25 @@ def _index_rows(rows):
         (
             """
                 phone number,name
-                +44 123, test1
-                +44 456,test2
+                +1 123, test1
+                +1 456,test2
             """,
             "sms",
             [
-                [('phone number', '+44 123'), ('name', 'test1')],
-                [('phone number', '+44 456'), ('name', 'test2')]
+                [('phone number', '+1 123'), ('name', 'test1')],
+                [('phone number', '+1 456'), ('name', 'test2')]
             ]
         ),
         (
             """
                 phone number,name
-                +44 123,
-                +44 456
+                +1 123,
+                +1 456
             """,
             "sms",
             [
-                [('phone number', '+44 123'), ('name', None)],
-                [('phone number', '+44 456'), ('name', None)]
+                [('phone number', '+1 123'), ('name', None)],
+                [('phone number', '+1 456'), ('name', None)]
             ]
         ),
         (
@@ -224,8 +224,8 @@ def test_get_rows_only_iterates_over_file_once(mocker):
         (
             """
                 phone number,name
-                07700900460, test1
-                +447700 900 460,test2
+                6502532222, test1
+                +1 650 253 2222,test2
                 ,
             """,
             'sms',
@@ -300,7 +300,7 @@ def test_get_rows_with_errors():
 
 @pytest.mark.parametrize('template_type, row_count, header, filler, row_with_error', [
     ('email', 500, "email address\n", "test@example.com\n", "test at example dot com"),
-    ('sms', 500, "phone number\n", "07900900123\n", "12345"),
+    ('sms', 500, "phone number\n", "6502532222\n", "12345"),
 ])
 def test_big_list_validates_right_through(template_type, row_count, header, filler, row_with_error):
     big_csv = RecipientCSV(
@@ -333,7 +333,7 @@ def test_big_list():
 
 def test_overly_big_list():
     big_csv = RecipientCSV(
-        "phonenumber,name\n" + ("07700900123,example\n" * (RecipientCSV.max_rows + 1)),
+        "phonenumber,name\n" + ("6502532222,example\n" * (RecipientCSV.max_rows + 1)),
         template_type='sms',
         placeholders=['name'],
     )
@@ -351,14 +351,14 @@ def test_overly_big_list():
         (
             """
                 phone number,name, date
-                +44 123,test1,today
-                +44456,    ,tomorrow
+                +1 123,test1,today
+                +1456,    ,tomorrow
                 ,,
                 , ,
             """,
             'sms',
             ['name'],
-            ['+44 123', '+44456'],
+            ['+1 123', '+1456'],
             [{'name': 'test1'}, {'name': None}]
         ),
         (
@@ -448,9 +448,9 @@ def test_get_recipient_respects_order(file_contents,
         (
             """
                 phone number,name
-                07700900460,test1
-                07700900460,test1
-                07700900460,test1
+                6502532222,test1
+                6502532222,test1
+                6502532222,test1
             """,
             'sms',
             ['phone number', 'name'],
@@ -550,11 +550,11 @@ def test_recipient_column(placeholders, file_contents, template_type):
         (
             """
                 phone number,name,date
-                07700900460,test1,test1
-                07700900460,test1
-                +44 123,test1,test1
-                07700900460,test1,test1
-                07700900460,test1
+                6502532222,test1,test1
+                6502532222,test1
+                +1 123,test1,test1
+                6502532222,test1,test1
+                6502532222,test1
                 +1644000000,test1,test1
                 ,test1,test1
             """,
@@ -564,7 +564,7 @@ def test_recipient_column(placeholders, file_contents, template_type):
         (
             """
                 phone number,name
-                07700900460,test1,test2
+                6502532222,test1,test2
             """,
             'sms',
             set(), set()
@@ -625,16 +625,14 @@ def test_bad_or_missing_data(
             phone number
             800000000000
             1234
-            +447900123
+            +17900123
         """,
         {0, 1, 2},
     ),
     (
         """
             phone number, country
-            1-202-555-0104, USA
-            +12025550104, USA
-            23051234567, Mauritius
+            +2302086859, Mauritius
         """,
         set(),
     ),
@@ -663,24 +661,24 @@ def test_errors_when_too_many_rows():
         (
             """
                 phone number
-                07700900460
+                6502532222
                 07700900461
                 07700900462
                 07700900463
             """,
             'sms',
-            ['+447700900460'],  # Same as first phone number but in different format
+            ['6502532222'],  # Same as first phone number but in different format
             3
         ),
         (
             """
                 phone number
-                7700900460
-                447700900461
+                6502532222
+                +16502532222
                 07700900462
             """,
             'sms',
-            ['07700900460', '07700900461', '07700900462', '07700900463', 'test@example.com'],
+            ['6502532222', '07700900461', '07700900462', '07700900463', 'test@example.com'],
             0
         ),
         (
@@ -690,7 +688,7 @@ def test_errors_when_too_many_rows():
                 not_in_whitelist@example.com
             """,
             'email',
-            ['in_whitelist@example.com', '07700900460'],  # Email case differs to the one in the CSV
+            ['in_whitelist@example.com', '6502532222'],  # Email case differs to the one in the CSV
             1
         )
     ]
@@ -731,10 +729,10 @@ def test_detects_rows_which_result_in_overly_long_messages():
     recipients = RecipientCSV(
         """
             phone number,placeholder
-            07700900460,1
-            07700900461,{one_under}
-            07700900462,{exactly}
-            07700900463,{one_over}
+            6502532222,1
+            6502532222,{one_under}
+            6502532223,{exactly}
+            6502532224,{one_over}
         """.format(
             one_under='a' * (SMS_CHAR_COUNT_LIMIT - 1),
             exactly='a' * SMS_CHAR_COUNT_LIMIT,
@@ -752,7 +750,7 @@ def test_detects_rows_which_result_in_overly_long_messages():
     "key, expected",
     sum([
         [(key, expected) for key in group] for expected, group in [
-            ('07700900460', (
+            ('6502532222', (
                 'phone number',
                 '   PHONENUMBER',
                 'phone_number',
@@ -780,7 +778,7 @@ def test_ignores_spaces_and_case_in_placeholders(key, expected):
     recipients = RecipientCSV(
         """
             phone number,FIRSTNAME, Last Name
-            07700900460, Jo, Bloggs
+            6502532222, Jo, Bloggs
         """,
         placeholders=['phone_number', 'First Name', 'lastname'],
         template_type='sms'
@@ -788,7 +786,7 @@ def test_ignores_spaces_and_case_in_placeholders(key, expected):
     first_row = recipients[0]
     assert first_row.get(key).data == expected
     assert first_row[key].data == expected
-    assert first_row.recipient == '07700900460'
+    assert first_row.recipient == '6502532222'
     assert len(first_row.items()) == 3
     assert not recipients.has_errors
 
@@ -843,7 +841,7 @@ def test_ignores_leading_whitespace_in_file(character, name):
 
 def test_error_if_too_many_recipients():
     recipients = RecipientCSV(
-        'phone number,\n07700900460,\n07700900460,\n07700900460,',
+        'phone number,\n6502532222,\n6502532222,\n6502532222,',
         placeholders=['phone_number'],
         template_type='sms',
         remaining_messages=2
@@ -854,7 +852,7 @@ def test_error_if_too_many_recipients():
 
 def test_dont_error_if_too_many_recipients_not_specified():
     recipients = RecipientCSV(
-        'phone number,\n07700900460,\n07700900460,\n07700900460,',
+        'phone number,\n6502532222,\n6502532222,\n6502532222,',
         placeholders=['phone_number'],
         template_type='sms'
     )
@@ -919,7 +917,7 @@ def test_multiple_sms_recipient_columns(international_sms):
     recipients = RecipientCSV(
         """
             phone number, phone number, phone_number, foo
-            07900 900111, 07900 900222, 07900 900333, bar
+            6502532222, 6502532223, 6502532224, bar
         """,
         template_type='sms',
         international_sms=international_sms,
@@ -927,10 +925,7 @@ def test_multiple_sms_recipient_columns(international_sms):
     assert recipients.column_headers == ['phone number', 'phone_number', 'foo']
     assert recipients.column_headers_as_column_keys == dict(phonenumber='', foo='').keys()
     assert recipients.rows[0].get('phone number').data == (
-        '07900 900333'
-    )
-    assert recipients.rows[0].get('phone_number').data == (
-        '07900 900333'
+        '6502532224'
     )
     assert recipients.rows[0].get('phone number').error is None
     assert recipients.duplicate_recipient_column_headers == OrderedSet([

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -192,7 +192,7 @@ def test_get_international_info(phone_number, expected_info):
     '(1)2345',
 ])
 def test_normalise_phone_number_raises_if_unparseable_characters(phone_number):
-    assert normalise_phone_number(phone_number) == False
+    assert normalise_phone_number(phone_number) is False
 
 
 @pytest.mark.parametrize('phone_number', [


### PR DESCRIPTION
You can now dynamically set the phone region using `PHONE_COUNTRY_CODE` and `PHONE_REGION_CODE` env variables. Defaults are `1` and `US` respectively.

It uses `phonenumbers` to extrapolate if a phone number is local or international vs hardcoded logic.