### PR TITLE
Add support for 'local' jinja filepaths

### DIFF
--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -1,4 +1,5 @@
 import math
+import sys
 from os import path
 from datetime import datetime
 
@@ -94,7 +95,7 @@ class Template():
             self.content,
             self.values,
             html='escape',
-            redact_missing_personalisation=self.redact_missing_personalisation
+            redact_missing_personalisation=self.redact_missing_personalisation,
         ))
 
     @property
@@ -327,6 +328,9 @@ class PlainTextEmailTemplate(WithSubjectTemplate):
 
 class HTMLEmailTemplate(WithSubjectTemplate):
 
+    # Instantiate with regular jinja for test mocking (tests expect this to exist before init)
+    jinja_template = template_env.get_template('email_template.jinja2')
+
     PREHEADER_LENGTH_IN_CHARACTERS = 256
 
     def __init__(
@@ -350,7 +354,10 @@ class HTMLEmailTemplate(WithSubjectTemplate):
         self.brand_colour = brand_colour
         self.brand_banner = brand_banner
         self.brand_name = brand_name
-        self.jinja_template = self.template_env.get_template('email_template.jinja2')
+        # set this again to make sure the correct either utils / downstream local jinja is used
+        # however, don't set if we are in a test environment (to preserve the above mock)
+        if("pytest" not in sys.modules):
+            self.jinja_template = self.template_env.get_template('email_template.jinja2')
 
     @property
     def preheader(self):
@@ -384,7 +391,7 @@ class HTMLEmailTemplate(WithSubjectTemplate):
             'brand_text': self.brand_text,
             'brand_colour': self.brand_colour,
             'brand_banner': self.brand_banner,
-            'brand_name': self.brand_name
+            'brand_name': self.brand_name,
         })
 
 

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -85,7 +85,6 @@ class Template():
                     'jinja_templates',
                 )
             ))
-        
 
     def __repr__(self):
         return "{}(\"{}\", {})".format(self.__class__.__name__, self.content, self.values)
@@ -257,7 +256,10 @@ class WithSubjectTemplate(Template):
         jinja_path=None,
     ):
         self._subject = template['subject']
-        super().__init__(template, values, redact_missing_personalisation=redact_missing_personalisation, jinja_path=jinja_path)
+        super().__init__(template,
+                         values,
+                         redact_missing_personalisation=redact_missing_personalisation,
+                         jinja_path=jinja_path)
 
     def __str__(self):
         return str(Field(
@@ -399,7 +401,10 @@ class EmailPreviewTemplate(WithSubjectTemplate):
         redact_missing_personalisation=False,
         jinja_path=None,
     ):
-        super().__init__(template, values, redact_missing_personalisation=redact_missing_personalisation, jinja_path=jinja_path)
+        super().__init__(template,
+                         values,
+                         redact_missing_personalisation=redact_missing_personalisation,
+                         jinja_path=jinja_path)
         self.from_name = from_name
         self.from_address = from_address
         self.reply_to = reply_to

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '40.0.3'
+__version__ = '41.0.0'
 # GDS version '34.0.1'


### PR DESCRIPTION
This allows the admin and API repos to use local jinja when testing, to avoid having to push changes through this repo before knowing if they are correct.

Part of: https://github.com/cds-snc/notification-api/issues/759