### PR TITLE
Added [] to sms preview template so we can translate it in the admin

### DIFF
--- a/notifications_utils/jinja_templates/sms_preview_template.jinja2
+++ b/notifications_utils/jinja_templates/sms_preview_template.jinja2
@@ -1,11 +1,11 @@
 {% if show_sender %}
   <p class="sms-message-sender">
-    From: {{ sender }}
+    [From]: {{ sender }}
   </p>
 {% endif %}
 {% if show_recipient %}
   <p class="sms-message-recipient">
-    To: {{ recipient }}
+    [To]: {{ recipient }}
   </p>
 {% endif %}
 <div class="sms-message-wrapper">


### PR DESCRIPTION
I tested this with `USE_LOCAL_JINJA_TEMPLATES` in notification-admin (thanks @brdunfield !). Translations are appearing correctly:
<img width="700" alt="Screen Shot 2020-05-08 at 11 39 11 AM" src="https://user-images.githubusercontent.com/5498428/81432666-90a5fe00-9120-11ea-8284-9e858cde9425.png">
Note: "phone number" is not coming from the template so that will have to be fixed in notification-admin.