### PR TITLE
SMS preview template FR fix

### DIFF
--- a/notifications_utils/jinja_templates/sms_preview_template.jinja2
+++ b/notifications_utils/jinja_templates/sms_preview_template.jinja2
@@ -1,11 +1,11 @@
 {% if show_sender %}
   <p class="sms-message-sender">
-    [From]: {{ sender }}
+    [From:] {{ sender }}
   </p>
 {% endif %}
 {% if show_recipient %}
   <p class="sms-message-recipient">
-    [To]: {{ recipient }}
+    [To:] {{ recipient }}
   </p>
 {% endif %}
 <div class="sms-message-wrapper">


### PR DESCRIPTION
Moved the colons inside the brackets so we can add a space before the colon for french:

<img width="545" alt="Screen Shot 2020-05-11 at 8 59 52 AM" src="https://user-images.githubusercontent.com/5498428/81576711-cc7dd500-9365-11ea-8728-ef49a6f0807e.png">
