### PR TITLE
French FIP Support

### DIFF
--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -24,7 +24,7 @@
 <span style="display: none;font-size: 1px;color: #fff; max-height: 0;">{{ preheader }}…</span>
 
 <!-- start primary template header EN + FR -->
-{% if govuk_banner or brand_name == "canada.ca-fr" %}
+{% if fip_banner_english or brand_name == "canada.ca-fr" %}
   <table role="presentation" width="100%" style="border-collapse: collapse; min-width: 100%; width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
     <tr>
       <td width="100%" height="53" bgcolor="#fff">
@@ -33,7 +33,7 @@
           <tr>
             <td>
               
-              {% if govuk_banner %}
+              {% if fip_banner_english %}
               <img
                 src="https://notification-alpha-canada-ca-asset-upload.s3.amazonaws.com/gov-canada-en-01.png"
                 alt="Government of Canada / Gouvernement du Canada"
@@ -66,7 +66,7 @@
   </table>
 {% endif %}
 
-{% if brand_banner %}
+{% if logo_with_background_colour %}
 {% set brand_colour = brand_colour if brand_colour else '#0b0c0c' %}
 <table role="presentation" width="100%" style="border-collapse: collapse;min-width: 100%;width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
   <tr style="margin-bottom:20px;">
@@ -119,7 +119,8 @@
   </tr>
 </table>
 {% endif %}
-{% if brand_logo and not brand_banner %}
+
+{% if brand_logo and not logo_with_background_colour %}
 <table
   role="presentation"
   class="content"
@@ -184,7 +185,7 @@
   </tr>
 </table>
 <!-- end main content -->
-{% if govuk_banner or brand_name == "canada.ca-fr" %}
+{% if fip_banner_english or brand_name == "canada.ca-fr" %}
 <table role="presentation" width="100%" style="border-collapse: collapse;min-width: 100%; width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
   <tr>
     <td width="100%" bgcolor="#fff"> 

--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -24,7 +24,7 @@
 <span style="display: none;font-size: 1px;color: #fff; max-height: 0;">{{ preheader }}…</span>
 
 <!-- start primary template header EN + FR -->
-{% if fip_banner_english or brand_name == "canada.ca-fr" %}
+{% if fip_banner_english or fip_banner_french %}
   <table role="presentation" width="100%" style="border-collapse: collapse; min-width: 100%; width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
     <tr>
       <td width="100%" height="53" bgcolor="#fff">
@@ -44,7 +44,7 @@
               {% endif %}
 
                 <!-- FR Fip -->
-               {% if brand_name == "canada.ca-fr" %}
+               {% if fip_banner_french %}
 
                <img
                 src="https://notification-alpha-canada-ca-asset-upload.s3.amazonaws.com/09d0d711-9c23-48ec-b21e-fc6acd2412bf-gov-canada-fr.png"
@@ -185,7 +185,7 @@
   </tr>
 </table>
 <!-- end main content -->
-{% if fip_banner_english or brand_name == "canada.ca-fr" %}
+{% if fip_banner_english or fip_banner_french %}
 <table role="presentation" width="100%" style="border-collapse: collapse;min-width: 100%; width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
   <tr>
     <td width="100%" bgcolor="#fff"> 

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -338,6 +338,7 @@ class HTMLEmailTemplate(WithSubjectTemplate):
         template,
         values=None,
         fip_banner_english=True,
+        fip_banner_french=False,
         complete_html=True,
         brand_logo=None,
         brand_text=None,
@@ -348,6 +349,7 @@ class HTMLEmailTemplate(WithSubjectTemplate):
     ):
         super().__init__(template, values, jinja_path=jinja_path)
         self.fip_banner_english = fip_banner_english
+        self.fip_banner_french = fip_banner_french
         self.complete_html = complete_html
         self.brand_logo = brand_logo
         self.brand_text = brand_text
@@ -386,6 +388,7 @@ class HTMLEmailTemplate(WithSubjectTemplate):
             ),
             'preheader': self.preheader,
             'fip_banner_english': self.fip_banner_english,
+            'fip_banner_french': self.fip_banner_french,
             'complete_html': self.complete_html,
             'brand_logo': self.brand_logo,
             'brand_text': self.brand_text,

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -337,22 +337,22 @@ class HTMLEmailTemplate(WithSubjectTemplate):
         self,
         template,
         values=None,
-        govuk_banner=True,
+        fip_banner_english=True,
         complete_html=True,
         brand_logo=None,
         brand_text=None,
         brand_colour=None,
-        brand_banner=False,
+        logo_with_background_colour=False,
         brand_name=None,
         jinja_path=None,
     ):
         super().__init__(template, values, jinja_path=jinja_path)
-        self.govuk_banner = govuk_banner
+        self.fip_banner_english = fip_banner_english
         self.complete_html = complete_html
         self.brand_logo = brand_logo
         self.brand_text = brand_text
         self.brand_colour = brand_colour
-        self.brand_banner = brand_banner
+        self.logo_with_background_colour = logo_with_background_colour
         self.brand_name = brand_name
         # set this again to make sure the correct either utils / downstream local jinja is used
         # however, don't set if we are in a test environment (to preserve the above mock)
@@ -385,12 +385,12 @@ class HTMLEmailTemplate(WithSubjectTemplate):
                 self.content, self.values
             ),
             'preheader': self.preheader,
-            'govuk_banner': self.govuk_banner,
+            'fip_banner_english': self.fip_banner_english,
             'complete_html': self.complete_html,
             'brand_logo': self.brand_logo,
             'brand_text': self.brand_text,
             'brand_colour': self.brand_colour,
-            'brand_banner': self.brand_banner,
+            'logo_with_background_colour': self.logo_with_background_colour,
             'brand_name': self.brand_name,
         })
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '41.0.0'
+__version__ = '42.1.0'
 # GDS version '34.0.1'

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -57,6 +57,18 @@ def test_fip_banner_english(show_banner):
         assert "gov-canada-en-01.png" not in str(email)
 
 
+@pytest.mark.parametrize(
+    "show_banner", (True, False)
+)
+def test_fip_banner_french(show_banner):
+    email = HTMLEmailTemplate({'content': 'hello world', 'subject': ''})
+    email.fip_banner_french = show_banner
+    if show_banner:
+        assert "gov-canada-fr.png" in str(email)
+    else:
+        assert "gov-canada-fr.png" not in str(email)
+
+
 def test_logo_with_background_colour_shows():
     email = str(HTMLEmailTemplate(
         {'content': 'hello world', 'subject': ''},
@@ -91,7 +103,7 @@ def test_brand_data_shows(brand_logo, brand_text, brand_colour):
         brand_colour=brand_colour
     ))
 
-    assert 'GOV.UK' not in email
+    assert 'Government of Canada' not in email
     if brand_logo:
         assert brand_logo in email
     if brand_text:
@@ -126,13 +138,27 @@ def test_alt_text_with_no_brand_text_and_fip_banner_english_shown():
     assert 'alt="Notify Logo"' in email
 
 
+def test_alt_text_with_no_brand_text_and_fip_banner_french_shown():
+    email = str(HTMLEmailTemplate(
+        {'content': 'hello world', 'subject': ''},
+        fip_banner_english=False,
+        fip_banner_french=True,
+        brand_logo='http://example.com/image.png',
+        brand_text=None,
+        logo_with_background_colour=True,
+        brand_name='Notify Logo'
+    ))
+    assert 'alt=" "' in email
+    assert 'alt="Notify Logo"' in email
+
+
 @pytest.mark.parametrize('logo_with_background_colour, brand_text, expected_alt_text', [
     (True, None, 'alt="Notify Logo"'),
     (True, 'Example', 'alt=" "'),
     (False, 'Example', 'alt=" "'),
     (False, None, 'alt="Notify Logo"'),
 ])
-def test_alt_text_with_no_fip_banner_english(logo_with_background_colour, brand_text, expected_alt_text):
+def test_alt_text_with_no_fip_banner(logo_with_background_colour, brand_text, expected_alt_text):
     email = str(HTMLEmailTemplate(
         {'content': 'hello world', 'subject': ''},
         fip_banner_english=False,

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -48,20 +48,20 @@ def test_default_template(content):
 @pytest.mark.parametrize(
     "show_banner", (True, False)
 )
-def test_govuk_banner(show_banner):
+def test_fip_banner_english(show_banner):
     email = HTMLEmailTemplate({'content': 'hello world', 'subject': ''})
-    email.govuk_banner = show_banner
+    email.fip_banner_english = show_banner
     if show_banner:
         assert "gov-canada-en-01.png" in str(email)
     else:
         assert "gov-canada-en-01.png" not in str(email)
 
 
-def test_brand_banner_shows():
+def test_logo_with_background_colour_shows():
     email = str(HTMLEmailTemplate(
         {'content': 'hello world', 'subject': ''},
-        brand_banner=True,
-        govuk_banner=False
+        logo_with_background_colour=True,
+        fip_banner_english=False
     ))
     assert (
         '<td width="10" height="10" valign="middle"></td>'
@@ -84,8 +84,8 @@ def test_brand_banner_shows():
 def test_brand_data_shows(brand_logo, brand_text, brand_colour):
     email = str(HTMLEmailTemplate(
         {'content': 'hello world', 'subject': ''},
-        brand_banner=True,
-        govuk_banner=False,
+        logo_with_background_colour=True,
+        fip_banner_english=False,
         brand_logo=brand_logo,
         brand_text=brand_text,
         brand_colour=brand_colour
@@ -100,45 +100,45 @@ def test_brand_data_shows(brand_logo, brand_text, brand_colour):
         assert 'bgcolor="{}"'.format(brand_colour) in email
 
 
-def test_alt_text_with_brand_text_and_govuk_banner_shown():
+def test_alt_text_with_brand_text_and_fip_banner_english_shown():
     email = str(HTMLEmailTemplate(
         {'content': 'hello world', 'subject': ''},
-        govuk_banner=True,
+        fip_banner_english=True,
         brand_logo='http://example.com/image.png',
         brand_text='Example',
-        brand_banner=True,
+        logo_with_background_colour=True,
         brand_name='Notify Logo'
     ))
     assert 'alt=" "' in email
     assert 'alt="Notify Logo"' not in email
 
 
-def test_alt_text_with_no_brand_text_and_govuk_banner_shown():
+def test_alt_text_with_no_brand_text_and_fip_banner_english_shown():
     email = str(HTMLEmailTemplate(
         {'content': 'hello world', 'subject': ''},
-        govuk_banner=True,
+        fip_banner_english=True,
         brand_logo='http://example.com/image.png',
         brand_text=None,
-        brand_banner=True,
+        logo_with_background_colour=True,
         brand_name='Notify Logo'
     ))
     assert 'alt=" "' in email
     assert 'alt="Notify Logo"' in email
 
 
-@pytest.mark.parametrize('brand_banner, brand_text, expected_alt_text', [
+@pytest.mark.parametrize('logo_with_background_colour, brand_text, expected_alt_text', [
     (True, None, 'alt="Notify Logo"'),
     (True, 'Example', 'alt=" "'),
     (False, 'Example', 'alt=" "'),
     (False, None, 'alt="Notify Logo"'),
 ])
-def test_alt_text_with_no_govuk_banner(brand_banner, brand_text, expected_alt_text):
+def test_alt_text_with_no_fip_banner_english(logo_with_background_colour, brand_text, expected_alt_text):
     email = str(HTMLEmailTemplate(
         {'content': 'hello world', 'subject': ''},
-        govuk_banner=False,
+        fip_banner_english=False,
         brand_logo='http://example.com/image.png',
         brand_text=brand_text,
-        brand_banner=brand_banner,
+        logo_with_background_colour=logo_with_background_colour,
         brand_name='Notify Logo'
     ))
 


### PR DESCRIPTION
Removes the check for a specific custom brand name, and adds a fip_banner_french variable check instead. This new variable will come from the admin / api (PRs going up shortly).

This PR will need to be merged to verify tests on the other two.