### PR TITLE
Restore old french fip branding for migration purposes

### DIFF
--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -24,7 +24,7 @@
 <span style="display: none;font-size: 1px;color: #fff; max-height: 0;">{{ preheader }}…</span>
 
 <!-- start primary template header EN + FR -->
-{% if fip_banner_english or fip_banner_french %}
+{% if fip_banner_english or fip_banner_french or brand_name == "canada.ca-fr" %}
   <table role="presentation" width="100%" style="border-collapse: collapse; min-width: 100%; width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
     <tr>
       <td width="100%" height="53" bgcolor="#fff">
@@ -44,7 +44,7 @@
               {% endif %}
 
                 <!-- FR Fip -->
-               {% if fip_banner_french %}
+               {% if fip_banner_french or brand_name == "canada.ca-fr" %}
 
                <img
                 src="https://notification-alpha-canada-ca-asset-upload.s3.amazonaws.com/09d0d711-9c23-48ec-b21e-fc6acd2412bf-gov-canada-fr.png"
@@ -185,7 +185,7 @@
   </tr>
 </table>
 <!-- end main content -->
-{% if fip_banner_english or fip_banner_french %}
+{% if fip_banner_english or fip_banner_french or brand_name == "canada.ca-fr" %}
 <table role="presentation" width="100%" style="border-collapse: collapse;min-width: 100%; width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
   <tr>
     <td width="100%" bgcolor="#fff"> 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '42.1.0'
+__version__ = '42.1.1'
 # GDS version '34.0.1'


### PR DESCRIPTION
When we next upgrade prod from staging, services currently using the french-fip hack will break until we manually migrate them to the new branding. This PR will stop this from happening, and retains the existing hack. Once prod has been migrated, we can remove the hack fully from the code.