### PR TITLE
Fix logging

### DIFF
--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -198,7 +198,7 @@ class JSONFormatter(BaseJSONFormatter):
             log_record[newkey] = log_record.pop(key)
         log_record['logType'] = "application"
         try:
-            log_record['message'] = log_record['message'].format(**log_record)
+            log_record['message'] = str(log_record['message'])
         except (KeyError, IndexError) as e:
             logger.exception("failed to format log message: {} not found".format(e))
         return log_record

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '42.1.1'
+__version__ = '42.1.2'
 # GDS version '34.0.1'


### PR DESCRIPTION
This PR is to fix the following Sentry error: https://sentry.io/organizations/canadian-digital-service/issues/1661335514/?project=1522963

This happened whenever a dict was sent to the logger:
https://github.com/cds-snc/notification-api/blob/675880e93b469464d4c7cc35eb84afa9793d1024/app/user/rest.py#L228
and
https://github.com/cds-snc/notification-api/blob/master/app/errors.py#L80

Not 100% sure how to test this before merging.