### PR TITLE
CSS changes for FIP emails

### DIFF
--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -190,7 +190,7 @@
               src="https://cds-notification-assets.s3.ca-central-1.amazonaws.com/wmms-blk.png"
               alt=" "
               height="25"
-              style="padding-top:20px;padding-right:10px;"
+              style="padding-top:20px;"
               border="0"
               style="Margin-top: 4px;"
             />

--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -25,11 +25,11 @@
 
 <!-- start primary template header EN + FR -->
 {% if fip_banner_english or fip_banner_french or brand_name == "canada.ca-fr" %}
-  <table role="presentation" width="100%" style="border-collapse: collapse; min-width: 100%; width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
+  <table role="presentation" width="100%" style="border-collapse: collapse; max-width: 100%; width: calc(100% - 10px) !important;" cellpadding="0" cellspacing="0" border="0">
     <tr>
       <td width="100%" height="53" bgcolor="#fff">
         <!-- start fip -->
-        <table width="580" role="presentation" width="100%" style="border-collapse: collapse; max-width: 580px;" cellpadding="0" cellspacing="0" border="0" align="left">
+        <table width="326" role="presentation" width="100%" style="border-collapse: collapse; max-width: 326px; width: calc(100% - 10px) !important;" cellpadding="0" cellspacing="0" border="0" align="left">
           <tr>
             <td>
               
@@ -38,7 +38,7 @@
                 src="https://notification-alpha-canada-ca-asset-upload.s3.amazonaws.com/gov-canada-en-01.png"
                 alt="Government of Canada / Gouvernement du Canada"
                 height="30"
-                style="padding-left:10px;padding-bottom:30px"
+                style="padding-left:10px;padding-bottom:30px; max-width: 100%; height: auto;"
                 border="0"
               />
               {% endif %}
@@ -50,7 +50,7 @@
                 src="https://notification-alpha-canada-ca-asset-upload.s3.amazonaws.com/09d0d711-9c23-48ec-b21e-fc6acd2412bf-gov-canada-fr.png"
                 alt="Gouvernement du Canada / Government of Canada"
                 height="30"
-                style="padding-left:10px;padding-bottom:30px"
+                style="padding-left:10px;padding-bottom:30px; max-width: 100%; height: auto;"
                 border="0"
               />
 
@@ -175,7 +175,7 @@
     cellpadding="0"
     cellspacing="0"
     border="0"
-    style="border-collapse: collapse; max-width: 580px; width: 100% !important;"
+    style="border-collapse: collapse; max-width: 560px; width: calc(100% - 10px)!important; margin-left: 10px;"
     width="100%"
 >
   <tr>

--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -25,13 +25,13 @@
 
 <!-- start primary template header EN + FR -->
 {% if fip_banner_english or fip_banner_french or brand_name == "canada.ca-fr" %}
-  <table role="presentation" style="border-collapse: collapse; min-width: 50%; max-width: 100%; width: 580px; margin: 0 auto;">
+  <table role="presentation" style="border-collapse: collapse; max-width: calc(100% - 10px); width: 580px; margin: 0 auto;">
     <tr>
-      <td width="100%" height="53" bgcolor="#fff">
+      <td width="100%" height="53" bgcolor="#fff" style="padding: 0;">
         <!-- start fip -->
         <table role="presentation" style="border-collapse: collapse; max-width: 326px; width: calc(100% - 10px) !important;" align="left">
           <tr>
-            <td>
+            <td style="padding-left: 10px;">
               
               {% if fip_banner_english %}
               <img
@@ -68,9 +68,9 @@
 
 {% if logo_with_background_colour %}
 {% set brand_colour = brand_colour if brand_colour else '#0b0c0c' %}
-<table role="presentation" style="border-collapse: collapse; min-width: 50%; max-width: 100%; width: 580px; margin: 0 auto;">
+<table role="presentation" style="border-collapse: collapse; max-width: 100%; width: 580px; margin: 0 auto;">
   <tr style="margin-bottom:20px;">
-    <td width="100%" height="53" bgcolor="{{brand_colour}}">
+    <td width="100%" height="53" bgcolor="{{brand_colour}}" style="padding: 0;">
       <table role="presentation" width="100%" style="border-collapse: collapse;max-width: 580px;" cellpadding="0" cellspacing="0" border="0" align="left">
         <tr>
           {% if brand_logo %}
@@ -91,7 +91,7 @@
             </td>
           {% endif %}
           {% if brand_text %}
-            <td width="100%" bgcolor="{{brand_colour}}" valign="middle" align="left" style="padding: 14px 0 14px 10px">
+            <td width="100%" bgcolor="{{brand_colour}}" valign="middle" align="left" style="padding: 10px 0 14px 10px">
               <span style="
                 display: block;
                 font-family: Helvetica, Arial, sans-serif;
@@ -124,20 +124,19 @@
 <table
   role="presentation"
   class="content"
-  align="center"
-  style="border-collapse: collapse; min-width: 50%; max-width: 100%; width: 580px; margin: 0 auto;"
+  style="border-collapse: collapse; max-width: 100%; width: 580px; margin: 0 auto;"
 >
   <tr>
-    <td>
+    <td style="padding: 0;">
       <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse">
         <tr>
-          <td height="24" width="100%" colspan="2"><br /></td>
+          <td height="24" width="100%" colspan="2" style="padding: 0;"><br /></td>
         </tr>
         <tr>
-          <td>
+          <td style="padding: 0;">
             <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse">
               <tr>
-                <td style="padding: 0 5px 0{% if brand_colour %} 7px; border-left: solid 2px {{ brand_colour }}{% else %} 0{% endif %}">
+                <td style="padding-left: 10px 5px 0{% if brand_colour %} 7px; border-left: solid 2px {{ brand_colour }}{% else %} 0{% endif %}">
                   <img src="{{ brand_logo }}" style="padding-left:0; display: block; border: 0" height="{% if brand_text -%} 27 {%- else -%} 108 {%- endif %}"
                         alt="{% if brand_text %} {% else -%}{{ brand_name }}{%- endif %}" />
                 </td>
@@ -167,11 +166,10 @@
 <table
     role="presentation"
     class="content"
-    align="center"
-    style="border-collapse: collapse; min-width: 50%; max-width: 100%; width: 580px; margin: 0 auto;"
+    style="border-collapse: collapse; max-width: calc(100% - 10px); width: 580px; margin: 0 auto;"
 >
   <tr>
-    <td style="font-family: Helvetica, Arial, sans-serif; font-size: 16px; line-height: 1.315789474; max-width: 580px;">
+    <td style="font-family: Helvetica, Arial, sans-serif; font-size: 16px; line-height: 1.315789474; max-width: 580px; padding-left: 10px;">
         {{ body|safe }}
     </td>
   </tr>
@@ -183,19 +181,19 @@
 <!-- so added the min-width: 320 to make sure it looks right on small screens -->
 <table role="presentation" width="100%" style="border-collapse: collapse; min-width: 320px; max-width: 100%; width: 580px; margin: 0 auto;">
   <tr>
-    <td width="100%" bgcolor="#fff" style="width:100%!important"> 
+    <td width="100%" bgcolor="#fff" style="width:100%!important; padding: 0;"> 
       <table role="presentation" style="border-collapse: collapse; width: 100%!important; text-align: right;" align="right">
         <tr>
-          <td bgcolor="#fff" style="text-align:right;width:100%!important">
+          <td bgcolor="#fff" style="text-align:right;width:100%!important; padding-left: 10px;">
             <!-- start fip -->  
             <img
-            src="https://cds-notification-assets.s3.ca-central-1.amazonaws.com/wmms-blk.png"
-            alt=" "
-            height="25"
-            style="padding-top:20px;padding-right:10px;"
-            border="0"
-            style="Margin-top: 4px;"
-          />
+              src="https://cds-notification-assets.s3.ca-central-1.amazonaws.com/wmms-blk.png"
+              alt=" "
+              height="25"
+              style="padding-top:20px;padding-right:10px;"
+              border="0"
+              style="Margin-top: 4px;"
+            />
             <!-- end fip -->
           </td>
         </tr>

--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -25,11 +25,11 @@
 
 <!-- start primary template header EN + FR -->
 {% if fip_banner_english or fip_banner_french or brand_name == "canada.ca-fr" %}
-  <table role="presentation" width="100%" style="border-collapse: collapse; max-width: 100%; width: calc(100% - 10px) !important;" cellpadding="0" cellspacing="0" border="0">
+  <table role="presentation" style="border-collapse: collapse; min-width: 50%; max-width: 100%; width: 580px; margin: 0 auto;">
     <tr>
       <td width="100%" height="53" bgcolor="#fff">
         <!-- start fip -->
-        <table width="326" role="presentation" width="100%" style="border-collapse: collapse; max-width: 326px; width: calc(100% - 10px) !important;" cellpadding="0" cellspacing="0" border="0" align="left">
+        <table role="presentation" style="border-collapse: collapse; max-width: 326px; width: calc(100% - 10px) !important;" align="left">
           <tr>
             <td>
               
@@ -38,7 +38,7 @@
                 src="https://notification-alpha-canada-ca-asset-upload.s3.amazonaws.com/gov-canada-en-01.png"
                 alt="Government of Canada / Gouvernement du Canada"
                 height="30"
-                style="padding-left:10px;padding-bottom:30px; max-width: 100%; height: auto;"
+                style="padding-bottom:30px; max-width: 100%; height: auto;"
                 border="0"
               />
               {% endif %}
@@ -50,7 +50,7 @@
                 src="https://notification-alpha-canada-ca-asset-upload.s3.amazonaws.com/09d0d711-9c23-48ec-b21e-fc6acd2412bf-gov-canada-fr.png"
                 alt="Gouvernement du Canada / Government of Canada"
                 height="30"
-                style="padding-left:10px;padding-bottom:30px; max-width: 100%; height: auto;"
+                style="padding-bottom:30px; max-width: 100%; height: auto;"
                 border="0"
               />
 
@@ -68,7 +68,7 @@
 
 {% if logo_with_background_colour %}
 {% set brand_colour = brand_colour if brand_colour else '#0b0c0c' %}
-<table role="presentation" width="100%" style="border-collapse: collapse;min-width: 100%;width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
+<table role="presentation" style="border-collapse: collapse; min-width: 50%; max-width: 100%; width: 580px; margin: 0 auto;">
   <tr style="margin-bottom:20px;">
     <td width="100%" height="53" bgcolor="{{brand_colour}}">
       <table role="presentation" width="100%" style="border-collapse: collapse;max-width: 580px;" cellpadding="0" cellspacing="0" border="0" align="left">
@@ -125,11 +125,7 @@
   role="presentation"
   class="content"
   align="center"
-  cellpadding="0"
-  cellspacing="0"
-  border="0"
-  style="border-collapse: collapse;max-width: 580px; width: 100% !important;"
-  width="100%"
+  style="border-collapse: collapse; min-width: 50%; max-width: 100%; width: 580px; margin: 0 auto;"
 >
   <tr>
     <td>
@@ -172,26 +168,25 @@
     role="presentation"
     class="content"
     align="center"
-    cellpadding="0"
-    cellspacing="0"
-    border="0"
-    style="border-collapse: collapse; max-width: 560px; width: calc(100% - 10px)!important; margin-left: 10px;"
-    width="100%"
+    style="border-collapse: collapse; min-width: 50%; max-width: 100%; width: 580px; margin: 0 auto;"
 >
   <tr>
-    <td width="560" style="font-family: Helvetica, Arial, sans-serif; font-size: 16px; line-height: 1.315789474; max-width: 560px;">
+    <td style="font-family: Helvetica, Arial, sans-serif; font-size: 16px; line-height: 1.315789474; max-width: 580px;">
         {{ body|safe }}
     </td>
   </tr>
 </table>
 <!-- end main content -->
+
 {% if fip_banner_english or fip_banner_french or brand_name == "canada.ca-fr" %}
-<table role="presentation" width="100%" style="border-collapse: collapse;min-width: 100%; width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
+<!-- for some reason some mobile clients don't want to respect the width: 580px / max-width:100% relationship here -->
+<!-- so added the min-width: 320 to make sure it looks right on small screens -->
+<table role="presentation" width="100%" style="border-collapse: collapse; min-width: 320px; max-width: 100%; width: 580px; margin: 0 auto;">
   <tr>
-    <td width="100%" bgcolor="#fff"> 
-      <table role="presentation" width="100%" style="border-collapse: collapse;max-width: 580px;" cellpadding="0" cellspacing="0" border="0" align="right">
+    <td width="100%" bgcolor="#fff" style="width:100%!important"> 
+      <table role="presentation" style="border-collapse: collapse; width: 100%!important; text-align: right;" align="right">
         <tr>
-          <td bgcolor="#fff" style="text-align:right;">
+          <td bgcolor="#fff" style="text-align:right;width:100%!important">
             <!-- start fip -->  
             <img
             src="https://cds-notification-assets.s3.ca-central-1.amazonaws.com/wmms-blk.png"

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '42.1.1'
+__version__ = '42.1.2'
 # GDS version '34.0.1'

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '42.1.2'
+__version__ = '42.1.3'
 # GDS version '34.0.1'

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -79,7 +79,7 @@ def test_logo_with_background_colour_shows():
         '<td width="10" height="10" valign="middle"></td>'
     ) not in email
     assert (
-        'role="presentation" width="100%" style="border-collapse: collapse;min-width: 100%;width: 100% !important;"'
+        'role="presentation" style="border-collapse: collapse; min-width: 50%; max-width: 100%; width: 580px; margin: 0 auto;"' # noqa
     ) in email
 
 

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -79,7 +79,7 @@ def test_logo_with_background_colour_shows():
         '<td width="10" height="10" valign="middle"></td>'
     ) not in email
     assert (
-        'role="presentation" style="border-collapse: collapse; min-width: 50%; max-width: 100%; width: 580px; margin: 0 auto;"' # noqa
+        'role="presentation" style="border-collapse: collapse; max-width: 100%; width: 580px; margin: 0 auto;"' # noqa
     ) in email
 
 


### PR DESCRIPTION
Jinja CSS changes to close: https://github.com/cds-snc/notification-api/issues/863

Emails should be centred on larger screens, and aligned with the Branding logo.
On smaller screens, there should be adequate padding on either side of the content.

Can be tested by running admin and api locally, setting USE_LOCAL_JINJA_TEMPLATES=True in api, and copying email_template.jinja2 into the api folder as directed in the readme. Send emails using the default fip and see how they display.