### PR TITLE
Allow max rows to be set from the outside

### DIFF
--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -48,8 +48,6 @@ optional_address_columns = {
 
 class RecipientCSV():
 
-    max_rows = 50000
-
     def __init__(
         self,
         file_data,
@@ -61,6 +59,7 @@ class RecipientCSV():
         template=None,
         remaining_messages=sys.maxsize,
         international_sms=False,
+        max_rows=50000,
     ):
         self.file_data = strip_whitespace(file_data, extra_characters=',')
         self.template_type = template_type
@@ -72,6 +71,7 @@ class RecipientCSV():
         self.international_sms = international_sms
         self.remaining_messages = remaining_messages
         self.rows_as_list = None
+        self.max_rows = max_rows
 
     def __len__(self):
         if not hasattr(self, '_len'):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '42.1.3'
+__version__ = '42.1.4'
 # GDS version '34.0.1'

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -644,10 +644,10 @@ def test_international_recipients(file_contents, rows_with_bad_recipients):
 
 def test_errors_when_too_many_rows():
     recipients = RecipientCSV(
-        "email address\n" + ("a@b.com\n" * (RecipientCSV.max_rows + 1)),
+        "email address\n" + ("a@b.com\n" * (50001)),
         template_type='email'
     )
-    assert RecipientCSV.max_rows == 50000
+    assert recipients.max_rows == 50000
     assert recipients.too_many_rows is True
     assert recipients.has_errors is True
     assert recipients.rows[49000]['email_address'].data == 'a@b.com'

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -318,7 +318,7 @@ def test_big_list_validates_right_through(template_type, row_count, header, fill
 
 def test_big_list():
     big_csv = RecipientCSV(
-        "email address,name\n" + ("a@b.com\n" * RecipientCSV.max_rows),
+        "email address,name\n" + ("a@b.com\n" * 50000),
         template_type='email',
         placeholders=['name'],
         max_errors_shown=100,
@@ -327,13 +327,13 @@ def test_big_list():
     )
     assert len(list(big_csv.initial_rows)) == 3
     assert len(list(big_csv.initial_rows_with_errors)) == 100
-    assert len(list(big_csv.rows)) == RecipientCSV.max_rows
+    assert len(list(big_csv.rows)) == big_csv.max_rows
     assert big_csv.has_errors
 
 
 def test_overly_big_list():
     big_csv = RecipientCSV(
-        "phonenumber,name\n" + ("6502532222,example\n" * (RecipientCSV.max_rows + 1)),
+        "phonenumber,name\n" + ("6502532222,example\n" * 50001),
         template_type='sms',
         placeholders=['name'],
     )


### PR DESCRIPTION
Still default to a max of 50k rows for CSVs, but allow it to be set in the admin or api. This is part of https://github.com/cds-snc/notification-api/issues/860 and groundwork for https://github.com/cds-snc/notification-admin/pull/550.