### PR TITLE
Rename whitelist

### DIFF
--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -55,7 +55,7 @@ class RecipientCSV():
         placeholders=None,
         max_errors_shown=20,
         max_initial_rows_shown=10,
-        whitelist=None,
+        safelist=None,
         template=None,
         remaining_messages=sys.maxsize,
         international_sms=False,
@@ -66,7 +66,7 @@ class RecipientCSV():
         self.placeholders = placeholders
         self.max_errors_shown = max_errors_shown
         self.max_initial_rows_shown = max_initial_rows_shown
-        self.whitelist = whitelist
+        self.safelist = safelist
         self.template = template if isinstance(template, Template) else None
         self.international_sms = international_sms
         self.remaining_messages = remaining_messages
@@ -82,15 +82,15 @@ class RecipientCSV():
         return self.rows[requested_index]
 
     @property
-    def whitelist(self):
-        return self._whitelist
+    def safelist(self):
+        return self._safelist
 
-    @whitelist.setter
-    def whitelist(self, value):
+    @safelist.setter
+    def safelist(self, value):
         try:
-            self._whitelist = list(value)
+            self._safelist = list(value)
         except TypeError:
-            self._whitelist = []
+            self._safelist = []
 
     @property
     def placeholders(self):
@@ -135,10 +135,10 @@ class RecipientCSV():
     def allowed_to_send_to(self):
         if self.template_type == 'letter':
             return True
-        if not self.whitelist:
+        if not self.safelist:
             return True
         return all(
-            allowed_to_send_to(row.recipient, self.whitelist)
+            allowed_to_send_to(row.recipient, self.safelist)
             for row in self.rows
         )
 
@@ -513,9 +513,9 @@ def format_phone_number_human_readable(phone_number):
     return phone_number
 
 
-def allowed_to_send_to(recipient, whitelist):
+def allowed_to_send_to(recipient, safelist):
     return format_recipient(recipient) in [
-        format_recipient(recipient) for recipient in whitelist
+        format_recipient(recipient) for recipient in safelist
     ]
 
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '42.1.5'
+__version__ = '43.0.0'
 # GDS version '34.0.1'

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -323,7 +323,7 @@ def test_big_list():
         placeholders=['name'],
         max_errors_shown=100,
         max_initial_rows_shown=3,
-        whitelist=["a@b.com"]
+        safelist=["a@b.com"]
     )
     assert len(list(big_csv.initial_rows)) == 3
     assert len(list(big_csv.initial_rows_with_errors)) == 100
@@ -656,7 +656,7 @@ def test_errors_when_too_many_rows():
 
 
 @pytest.mark.parametrize(
-    "file_contents,template_type,whitelist,count_of_rows_with_errors",
+    "file_contents,template_type,safelist,count_of_rows_with_errors",
     [
         (
             """
@@ -684,21 +684,21 @@ def test_errors_when_too_many_rows():
         (
             """
                 email address
-                IN_WHITELIST@EXAMPLE.COM
-                not_in_whitelist@example.com
+                IN_SAFELIST@EXAMPLE.COM
+                not_in_safelist@example.com
             """,
             'email',
-            ['in_whitelist@example.com', '6502532222'],  # Email case differs to the one in the CSV
+            ['in_safelist@example.com', '6502532222'],  # Email case differs to the one in the CSV
             1
         )
     ]
 )
-def test_recipient_whitelist(file_contents, template_type, whitelist, count_of_rows_with_errors):
+def test_recipient_safelist(file_contents, template_type, safelist, count_of_rows_with_errors):
 
     recipients = RecipientCSV(
         file_contents,
         template_type=template_type,
-        whitelist=whitelist
+        safelist=safelist
     )
 
     if count_of_rows_with_errors:
@@ -706,17 +706,17 @@ def test_recipient_whitelist(file_contents, template_type, whitelist, count_of_r
     else:
         assert recipients.allowed_to_send_to
 
-    # Make sure the whitelist isn’t emptied by reading it. If it’s an iterator then
+    # Make sure the safelist isn’t emptied by reading it. If it’s an iterator then
     # there’s a risk that it gets emptied after being read once
-    recipients.whitelist = (str(fake_number) for fake_number in range(7700900888, 7700900898))
-    list(recipients.whitelist)
+    recipients.safelist = (str(fake_number) for fake_number in range(7700900888, 7700900898))
+    list(recipients.safelist)
     assert not recipients.allowed_to_send_to
     assert recipients.has_errors
 
-    # An empty whitelist is treated as no whitelist at all
-    recipients.whitelist = []
+    # An empty safelist is treated as no safelist at all
+    recipients.safelist = []
     assert recipients.allowed_to_send_to
-    recipients.whitelist = itertools.chain()
+    recipients.safelist = itertools.chain()
     assert recipients.allowed_to_send_to
 
 

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -370,13 +370,13 @@ def test_valid_address_line_does_not_raise_error():
 
 
 @pytest.mark.parametrize("phone_number", valid_local_phone_numbers)
-def test_validates_against_whitelist_of_phone_numbers(phone_number):
+def test_validates_against_safelist_of_phone_numbers(phone_number):
     assert allowed_to_send_to(phone_number, ['6502532222', '07700900460', 'test@example.com'])
     assert not allowed_to_send_to(phone_number, ['07700900460', '07700900461', 'test@example.com'])
 
 
 @pytest.mark.parametrize("email_address", valid_email_addresses)
-def test_validates_against_whitelist_of_email_addresses(email_address):
+def test_validates_against_safelist_of_email_addresses(email_address):
     assert not allowed_to_send_to(email_address, ['very_special_and_unique@example.com'])
 
 


### PR DESCRIPTION
re https://github.com/cds-snc/notification-api/issues/962

change "whitelist" to "safelist". This changes this parameters for class `RecipientCSV` and thus is a breaking change.

See [How to work with notification-utils locally
](https://docs.google.com/document/d/1CMCR4wiTisA3qZdkomuk0zriqeyVp-od5ZuUO95wATM)

The notification-admin hasn't been modified to use this new version yet.