### PR TITLE
Support translation of template fields

### DIFF
--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -57,7 +57,8 @@ class Field:
     placeholder_tag = "<span class='placeholder'>(({}))</span>"
     conditional_placeholder_tag = "<span class='placeholder-conditional'>(({}??</span>{}))"
     placeholder_tag_no_brackets = "<span class='placeholder-no-brackets'>{}</span>"
-    placeholder_tag_redacted = "<span class='placeholder-redacted'>hidden</span>"
+    placeholder_tag_no_brackets_translated = "<span class='placeholder-no-brackets'>[{}]</span>"
+    placeholder_tag_redacted = "<span class='placeholder-redacted'>[hidden]</span>"
 
     def __init__(
         self,
@@ -67,12 +68,15 @@ class Field:
         html='strip',
         markdown_lists=False,
         redact_missing_personalisation=False,
+        translated=False
     ):
         self.content = content
         self.values = values
         self.markdown_lists = markdown_lists
         if not with_brackets:
             self.placeholder_tag = self.placeholder_tag_no_brackets
+        if translated:
+            self.placeholder_tag = self.placeholder_tag_no_brackets_translated
         self.sanitizer = {
             'strip': strip_html,
             'escape': escape_html,

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -56,15 +56,13 @@ class Field:
     )
     placeholder_tag = "<span class='placeholder'>(({}))</span>"
     conditional_placeholder_tag = "<span class='placeholder-conditional'>(({}??</span>{}))"
-    placeholder_tag_no_brackets = "<span class='placeholder-no-brackets'>{}</span>"
-    placeholder_tag_no_brackets_translated = "<span class='placeholder-no-brackets'>[{}]</span>"
+    placeholder_tag_translated = "<span class='placeholder-no-brackets'>[{}]</span>"
     placeholder_tag_redacted = "<span class='placeholder-redacted'>[hidden]</span>"
 
     def __init__(
         self,
         content,
         values=None,
-        with_brackets=True,
         html='strip',
         markdown_lists=False,
         redact_missing_personalisation=False,
@@ -73,10 +71,8 @@ class Field:
         self.content = content
         self.values = values
         self.markdown_lists = markdown_lists
-        if not with_brackets:
-            self.placeholder_tag = self.placeholder_tag_no_brackets
         if translated:
-            self.placeholder_tag = self.placeholder_tag_no_brackets_translated
+            self.placeholder_tag = self.placeholder_tag_translated
         self.sanitizer = {
             'strip': strip_html,
             'escape': escape_html,

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -541,7 +541,7 @@ class LetterPreviewTemplate(WithSubjectTemplate):
                 }) else self.values
             ),
             html='escape',
-            with_brackets=False
+            translated=True
         )).then(
             strip_pipes
         ).then(

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -226,7 +226,7 @@ class SMSPreviewTemplate(SMSMessageTemplate):
         return Markup(self.jinja_template.render({
             'sender': self.sender,
             'show_sender': self.show_sender,
-            'recipient': Field('((phone number))', self.values, with_brackets=False, html='escape'),
+            'recipient': Field('((phone number))', self.values, html='escape', translated=True),
             'show_recipient': self.show_recipient,
             'body': Take(Field(
                 self.content,
@@ -430,7 +430,7 @@ class EmailPreviewTemplate(WithSubjectTemplate):
             'from_name': escape_html(self.from_name),
             'from_address': self.from_address,
             'reply_to': self.reply_to,
-            'recipient': Field("((email address))", self.values, with_brackets=False),
+            'recipient': Field("((email address))", self.values, translated=True),
             'show_recipient': self.show_recipient
         }))
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '43.0.2'
+__version__ = '43.0.4'
 # GDS version '34.0.1'

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -182,45 +182,40 @@ def test_formatting_of_placeholders(content, expected):
 
 
 @pytest.mark.parametrize(
-    "content,expected,with_brackets,translated,values", [
+    "content,expected,translated,values", [
         (
             "((colour))",
-            "<span class='placeholder-no-brackets'>colour</span>",
-            False,
+            "<span class='placeholder'>((colour))</span>",
             False,
             None
         ),
         (
             "((colour))",
             "<span class='placeholder-no-brackets'>[colour]</span>",
-            False,
             True,
             None
         ),
         (
             "((colour))",
             "blue",
-            True,
             False,
             {'colour': 'blue'}
         ),
         (
             "((colour))",
             "blue",
-            False,
             True,
             {'colour': 'blue'}
         ),
     ]
 )
-def test_formatting_of_placeholders_without_brackets_or_translated(
+def test_formatting_of_placeholders_translated(
     content,
     expected,
-    with_brackets,
     translated,
     values
 ):
-    field = Field(content, with_brackets=with_brackets, translated=translated, values=values)
+    field = Field(content, translated=translated, values=values)
     assert str(field) == expected
 
 

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -116,7 +116,7 @@ def test_replacement_of_placeholders(template_content, data, expected):
         (
             "((code)) is your security code",
             {},
-            "<span class='placeholder-redacted'>hidden</span> is your security code"
+            "<span class='placeholder-redacted'>[hidden]</span> is your security code"
         ),
         (
             "Hey ((name)), click http://example.com/reset-password/?token=((token))",
@@ -124,7 +124,7 @@ def test_replacement_of_placeholders(template_content, data, expected):
             (
                 "Hey Example, click "
                 "http://example.com/reset-password/?token="
-                "<span class='placeholder-redacted'>hidden</span>"
+                "<span class='placeholder-redacted'>[hidden]</span>"
             )
         ),
     ]
@@ -179,6 +179,49 @@ def test_optional_redacting_of_missing_values(template_content, data, expected):
 )
 def test_formatting_of_placeholders(content, expected):
     assert str(Field(content)) == expected
+
+
+@pytest.mark.parametrize(
+    "content,expected,with_brackets,translated,values", [
+        (
+            "((colour))",
+            "<span class='placeholder-no-brackets'>colour</span>",
+            False,
+            False,
+            None
+        ),
+        (
+            "((colour))",
+            "<span class='placeholder-no-brackets'>[colour]</span>",
+            False,
+            True,
+            None
+        ),
+        (
+            "((colour))",
+            "blue",
+            True,
+            False,
+            {'colour': 'blue'}
+        ),
+        (
+            "((colour))",
+            "blue",
+            False,
+            True,
+            {'colour': 'blue'}
+        ),
+    ]
+)
+def test_formatting_of_placeholders_without_brackets_or_translated(
+    content,
+    expected,
+    with_brackets,
+    translated,
+    values
+):
+    field = Field(content, with_brackets=with_brackets, translated=translated, values=values)
+    assert str(field) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -863,13 +863,13 @@ def test_subject_line_gets_replaced():
     (EmailPreviewTemplate, {}, [
         mock.call('content', {}, html='escape', markdown_lists=True, redact_missing_personalisation=False),
         mock.call('subject', {}, html='escape', redact_missing_personalisation=False),
-        mock.call('((email address))', {}, with_brackets=False),
+        mock.call('((email address))', {}, translated=True),
     ]),
     (SMSMessageTemplate, {}, [
         mock.call('content', {}, html='passthrough'),
     ]),
     (SMSPreviewTemplate, {}, [
-        mock.call('((phone number))', {}, with_brackets=False, html='escape'),
+        mock.call('((phone number))', {}, translated=True, html='escape'),
         mock.call('content', {}, html='escape', redact_missing_personalisation=False),
     ]),
     (LetterPreviewTemplate, {'contact_block': 'www.gov.uk'}, [
@@ -911,10 +911,10 @@ def test_subject_line_gets_replaced():
     (EmailPreviewTemplate, {'redact_missing_personalisation': True}, [
         mock.call('content', {}, html='escape', markdown_lists=True, redact_missing_personalisation=True),
         mock.call('subject', {}, html='escape', redact_missing_personalisation=True),
-        mock.call('((email address))', {}, with_brackets=False),
+        mock.call('((email address))', {}, translated=True),
     ]),
     (SMSPreviewTemplate, {'redact_missing_personalisation': True}, [
-        mock.call('((phone number))', {}, with_brackets=False, html='escape'),
+        mock.call('((phone number))', {}, translated=True, html='escape'),
         mock.call('content', {}, html='escape', redact_missing_personalisation=True),
     ]),
     (LetterPreviewTemplate, {'contact_block': 'www.gov.uk', 'redact_missing_personalisation': True}, [
@@ -1206,7 +1206,7 @@ def test_email_preview_shows_reply_to_address(extra_args):
 @pytest.mark.parametrize('template_values, expected_content', [
     (
         {},
-        '<span class=\'placeholder-no-brackets\'>email address</span>'
+        '<span class=\'placeholder-no-brackets\'>[email address]</span>'
     ),
     (
         {'email address': 'test@example.com'},

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -567,25 +567,25 @@ def test_sms_message_normalises_newlines(content):
 @mock.patch('notifications_utils.template.strip_pipes', side_effect=lambda x: x)
 @pytest.mark.parametrize('values, expected_address', [
     ({}, Markup(
-        "<span class='placeholder-no-brackets'>address line 1</span>\n"
-        "<span class='placeholder-no-brackets'>address line 2</span>\n"
-        "<span class='placeholder-no-brackets'>address line 3</span>\n"
-        "<span class='placeholder-no-brackets'>address line 4</span>\n"
-        "<span class='placeholder-no-brackets'>address line 5</span>\n"
-        "<span class='placeholder-no-brackets'>address line 6</span>\n"
-        "<span class='placeholder-no-brackets'>postcode</span>"
+        "<span class='placeholder-no-brackets'>[address line 1]</span>\n"
+        "<span class='placeholder-no-brackets'>[address line 2]</span>\n"
+        "<span class='placeholder-no-brackets'>[address line 3]</span>\n"
+        "<span class='placeholder-no-brackets'>[address line 4]</span>\n"
+        "<span class='placeholder-no-brackets'>[address line 5]</span>\n"
+        "<span class='placeholder-no-brackets'>[address line 6]</span>\n"
+        "<span class='placeholder-no-brackets'>[postcode]</span>"
     )),
     ({
         'address line 1': '123 Fake Street',
         'address line 6': 'United Kingdom',
     }, Markup(
         "123 Fake Street\n"
-        "<span class='placeholder-no-brackets'>address line 2</span>\n"
-        "<span class='placeholder-no-brackets'>address line 3</span>\n"
-        "<span class='placeholder-no-brackets'>address line 4</span>\n"
-        "<span class='placeholder-no-brackets'>address line 5</span>\n"
+        "<span class='placeholder-no-brackets'>[address line 2]</span>\n"
+        "<span class='placeholder-no-brackets'>[address line 3]</span>\n"
+        "<span class='placeholder-no-brackets'>[address line 4]</span>\n"
+        "<span class='placeholder-no-brackets'>[address line 5]</span>\n"
         "United Kingdom\n"
-        "<span class='placeholder-no-brackets'>postcode</span>"
+        "<span class='placeholder-no-brackets'>[postcode]</span>"
     )),
     ({
         'address line 1': '123 Fake Street',
@@ -764,13 +764,13 @@ def test_letter_image_renderer(
         'too_many_pages': expected_oversized,
         'address': (
             "<ul>"
-            "<li><span class='placeholder-no-brackets'>address line 1</span></li>"
-            "<li><span class='placeholder-no-brackets'>address line 2</span></li>"
-            "<li><span class='placeholder-no-brackets'>address line 3</span></li>"
-            "<li><span class='placeholder-no-brackets'>address line 4</span></li>"
-            "<li><span class='placeholder-no-brackets'>address line 5</span></li>"
-            "<li><span class='placeholder-no-brackets'>address line 6</span></li>"
-            "<li><span class='placeholder-no-brackets'>postcode</span></li>"
+            "<li><span class='placeholder-no-brackets'>[address line 1]</span></li>"
+            "<li><span class='placeholder-no-brackets'>[address line 2]</span></li>"
+            "<li><span class='placeholder-no-brackets'>[address line 3]</span></li>"
+            "<li><span class='placeholder-no-brackets'>[address line 4]</span></li>"
+            "<li><span class='placeholder-no-brackets'>[address line 5]</span></li>"
+            "<li><span class='placeholder-no-brackets'>[address line 6]</span></li>"
+            "<li><span class='placeholder-no-brackets'>[postcode]</span></li>"
             "</ul>"
         ),
         'contact_block': '10 Downing Street',
@@ -883,7 +883,7 @@ def test_subject_line_gets_replaced():
             '((address line 5))\n'
             '((address line 6))\n'
             '((postcode))'
-        ), {}, with_brackets=False, html='escape'),
+        ), {}, translated=True, html='escape'),
         mock.call('www.gov.uk', {}, html='escape', redact_missing_personalisation=False),
     ]),
     (LetterImageTemplate, {
@@ -897,7 +897,7 @@ def test_subject_line_gets_replaced():
             '((address line 5))\n'
             '((address line 6))\n'
             '((postcode))'
-        ), {}, with_brackets=False, html='escape'),
+        ), {}, translated=True, html='escape'),
         mock.call('www.gov.uk', {}, html='escape', redact_missing_personalisation=False),
         mock.call('subject', {}, html='escape', redact_missing_personalisation=False),
         mock.call('content', {}, html='escape', markdown_lists=True, redact_missing_personalisation=False),
@@ -928,7 +928,7 @@ def test_subject_line_gets_replaced():
             '((address line 5))\n'
             '((address line 6))\n'
             '((postcode))'
-        ), {}, with_brackets=False, html='escape'),
+        ), {}, translated=True, html='escape'),
         mock.call('www.gov.uk', {}, html='escape', redact_missing_personalisation=True),
     ]),
 ])
@@ -981,13 +981,13 @@ def test_templates_handle_html_and_redacting(
         mock.call(Markup('subject')),
         mock.call(Markup('<p>content</p>')),
         mock.call((
-            "<span class='placeholder-no-brackets'>address line 1</span>\n"
-            "<span class='placeholder-no-brackets'>address line 2</span>\n"
-            "<span class='placeholder-no-brackets'>address line 3</span>\n"
-            "<span class='placeholder-no-brackets'>address line 4</span>\n"
-            "<span class='placeholder-no-brackets'>address line 5</span>\n"
-            "<span class='placeholder-no-brackets'>address line 6</span>\n"
-            "<span class='placeholder-no-brackets'>postcode</span>"
+            "<span class='placeholder-no-brackets'>[address line 1]</span>\n"
+            "<span class='placeholder-no-brackets'>[address line 2]</span>\n"
+            "<span class='placeholder-no-brackets'>[address line 3]</span>\n"
+            "<span class='placeholder-no-brackets'>[address line 4]</span>\n"
+            "<span class='placeholder-no-brackets'>[address line 5]</span>\n"
+            "<span class='placeholder-no-brackets'>[address line 6]</span>\n"
+            "<span class='placeholder-no-brackets'>[postcode]</span>"
         )),
         mock.call(Markup('www.gov.uk')),
         mock.call(Markup('subject')),


### PR DESCRIPTION
Related to https://github.com/cds-snc/notification-api/issues/850

It's possible to translate things in Jinja templates by adding brackets. This PR adds the possibility to translate placeholders.

The idea is to add brackets so that they'll be translated at the rendering phase.