### PR TITLE
Bug: hyphens_with_en_dashes cleans up pipes

### DIFF
--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -64,7 +64,7 @@ smartypants.tags_to_skip = smartypants.tags_to_skip + ['a']
 
 whitespace_before_punctuation = re.compile(r'[ \t]+([,\.])')
 
-hyphens_surrounded_by_spaces = re.compile(r'\s+[-|–|—]{1,3}\s+')
+hyphens_surrounded_by_spaces = re.compile(r'\s+[-–—]{1,3}\s+')
 
 multiple_newlines = re.compile(r'((\n)\2{2,})')
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '43.0.4'
+__version__ = '43.0.5'
 # GDS version '34.0.1'

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -192,6 +192,17 @@ def test_escaping_govuk_in_email_templates(template_content, expected):
 
 
 @pytest.mark.parametrize(
+    "subject,expected", [
+        ("bonjour | hi", "bonjour | hi"),
+        ("bonjour .", "bonjour."),
+        ('double -- dash', 'double \u2013 dash'),
+    ]
+)
+def test_subject_is_cleaned_up(subject, expected):
+    assert expected == HTMLEmailTemplate({'content': '', 'subject': subject}).subject
+
+
+@pytest.mark.parametrize(
     "prefix, body, expected", [
         ("a", "b", "a: b"),
         (None, "b", "b"),
@@ -959,6 +970,10 @@ def test_smart_quotes(dumb, smart):
     (
         '2004-2008',
         '2004-2008',  # no replacement
+    ),
+    (
+        'bonjour | hi',
+        'bonjour | hi',
     ),
 ])
 def test_en_dashes(nasty, nice):


### PR DESCRIPTION
Follow up of https://github.com/cds-snc/notification-utils/pull/61. Turns out it's not solved!

Turns out that another method has a bug, where pipes are cleaned where only dashes should be cleaned.

Cleaned up the regex, added a test for this method and a dedicated test for the subject field.