### PR TITLE
Cache DNS requests for StatsD host

### DIFF
--- a/notifications_utils/clients/statsd/statsd_client.py
+++ b/notifications_utils/clients/statsd/statsd_client.py
@@ -1,6 +1,16 @@
-from statsd.client.base import StatsClientBase
-from socket import socket, AF_INET, SOCK_DGRAM
+import random
+import time
+from collections import deque
+from socket import AF_INET, SOCK_DGRAM, gethostbyname, socket
+
+import cachetools.func
 from flask import current_app
+from statsd.client.base import StatsClientBase
+
+
+def time_monotonic_with_jitter():
+    jitter = random.uniform(-3, 3)
+    return time.monotonic() + jitter
 
 
 class NotifyStatsClient(StatsClientBase):
@@ -9,10 +19,32 @@ class NotifyStatsClient(StatsClientBase):
         self._port = port
         self._prefix = prefix
         self._sock = socket(AF_INET, SOCK_DGRAM)
+        self._queue = deque()
+
+    def _resolve(self, addr):
+        return gethostbyname(addr)
+
+    @cachetools.func.ttl_cache(maxsize=2, ttl=10, timer=time_monotonic_with_jitter)
+    def _cached_host(self):
+        try:
+            return self._resolve(self._host)
+        except Exception as e:
+            # If we get an error, store `None` in the cache so that we don't keep
+            # trying to retrieve the DNS if DNS server is having issues
+            current_app.logger.warning('Error resolving statsd DNS: {}'.format(str(e)))
+            return None
 
     def _send(self, data):
+        self._queue.append(data)
         try:
-            self._sock.sendto(data.encode('ascii'), (self._host, self._port))
+            host = self._cached_host()
+            # If we can't resolve DNS, then host is `None`
+            # Don't send to statsd, data will be sent later
+            if host is None:
+                return
+
+            for elem in self._queue:
+                self._sock.sendto(elem.encode('ascii'), (host, self._port))
         except Exception as e:
             current_app.logger.warning('Error sending statsd metric: {}'.format(str(e)))
             pass

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '43.0.6'
+__version__ = '43.1.0'
 # GDS version '34.0.1'

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'bleach==3.2.1',
+        'cachetools==4.1.0',
         'mistune==0.8.4',
         'requests==2.24.0',
         'python-json-logger==2.0.0',


### PR DESCRIPTION
We have seen recently that sending requests to StatsD may take an enormous amount of time, leading to slow responses (> 1s). Our custom StatsD client may be the culprit. With our current implementation, we reuse a single socket to send requests but we resolve DNS each time. The original client doesn't do this, but [caches the DNS response forever](https://github.com/jsocol/pystatsd/blob/f3f304b4b2c3d5eddeb9f4977d9c82c64c37a052/statsd/client/udp.py#L34-L44). This is not appropriate for us as this pod could have its IP changed by Kubernetes as it rearranges pods.

My assumption is that sometimes DNS requests can take a larger amount of time. It's also unreasonable to resolve DNS constantly, this may lead to network congestion or overload the k8s DNS server.

GDS had performance issues using the single socket setup, when resolving DNS requests every time. They introduced caching https://github.com/alphagov/notifications-utils/commit/48f61f87cc2e8898c67e918bc8c30763f0d0113c + https://github.com/alphagov/notifications-utils/commit/7ca008f05a00e376e7b11e6b4086c504d20ad0b5. I have reused most of their code to introduce the same mechanism. The only addition is that I don't throw away data if host cannot be resolved for 19s, I'm saving data to a queue and these points will be sent later when DNS is available again.

See discussion on Slack https://gcdigital.slack.com/archives/CNWA63606/p1602854344028800