### PR TITLE
Update preview template styles

### DIFF
--- a/notifications_utils/jinja_templates/email_preview_template.jinja2
+++ b/notifications_utils/jinja_templates/email_preview_template.jinja2
@@ -1,39 +1,39 @@
-<div class="email-message">
-  <table class="email-message-meta">
+<div class="email-message mb-12 border border-solid border-gray-grey2">
+  <table class="email-message-meta m-0 text-smaller leading-tight font-normal">
     <tbody>
       {% if show_recipient %}
         {% if from_name %}
           <tr>
-            <th>[From]</th>
-            <td>
+            <th class="email-message-table pl-doubleGutter text-gray-grey1">[From]</th>
+            <td class="email-message-table">
               {{ from_name }}
             </td>
           </tr>
         {% endif %}
         {% if reply_to %}
           <tr>
-            <th>[Reply to]</th>
-            <td>
+            <th class="email-message-table pl-doubleGutter text-gray-grey1">[Reply to]</th>
+            <td class="email-message-table">
               {{ reply_to }}
             </td>
           </tr>
         {% endif %}
         <tr>
-          <th>[To]</th>
-          <td>
+          <th class="email-message-table pl-doubleGutter text-gray-grey1">[To]</th>
+          <td class="email-message-table">
             {{ recipient }}
           </td>
         </tr>
       {% endif %}
-      <tr class="email-message-meta">
-        <th>[Subject]</th>
-        <td>
+      <tr class="email-message-meta m-0 text-smaller leading-tight font-normal">
+        <th class="email-message-table pl-doubleGutter text-gray-grey1">[Subject]</th>
+        <td class="email-message-table">
           {{ subject }}
         </td>
       </tr>
     </tbody>
   </table>
-  <div class="email-message-body">
+  <div class="email-message-body w-full m-0 relative break-words clear-both box-border px-doubleGutter pt-gutterHalf pb-0">
     {{ body }}
   </div>
 </div>

--- a/notifications_utils/jinja_templates/sms_preview_template.jinja2
+++ b/notifications_utils/jinja_templates/sms_preview_template.jinja2
@@ -1,10 +1,10 @@
 {% if show_sender %}
-  <p class="sms-message-sender">
+  <p class="sms-message-sender -mb-4">
     [From:] {{ sender }}
   </p>
 {% endif %}
 {% if show_recipient %}
-  <p class="sms-message-recipient">
+  <p class="sms-message-recipient mt-4">
     [To:] {{ recipient }}
   </p>
 {% endif %}

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '43.1.2'
+__version__ = '43.1.3'
 # GDS version '34.0.1'

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1173,7 +1173,7 @@ def test_email_preview_shows_from_name(extra_args):
         {'content': 'content', 'subject': 'subject'},
         **extra_args
     )
-    assert '<th>[From]</th>' in str(template)
+    assert '<th class="email-message-table pl-doubleGutter text-gray-grey1">[From]</th>' in str(template)
     assert 'Example service' in str(template)
     assert 'test@example.com' not in str(template)
 
@@ -1199,7 +1199,7 @@ def test_email_preview_shows_reply_to_address(extra_args):
         {'content': 'content', 'subject': 'subject'},
         **extra_args
     )
-    assert '<th>[Reply to]</th>' in str(template)
+    assert '<th class="email-message-table pl-doubleGutter text-gray-grey1">[Reply to]</th>' in str(template)
     assert 'test@example.com' in str(template)
 
 


### PR DESCRIPTION
The admin pulls from these files to show the previews. These ones are okay to modify / tailwind-ify here as they are *only* used in the admin previews. Note that for actual email styling we will not be able to do this.

There will be an associated PR going up for admin as well