### PR TITLE
Store email assets on canada.ca

### DIFF
--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -32,10 +32,10 @@
         <table role="presentation" style="border-collapse: collapse; max-width: 326px; width: calc(100% - 10px) !important;" align="left">
           <tr>
             <td style="padding-left: 10px;">
-              
+
               {% if fip_banner_english %}
               <img
-                src="https://notification-alpha-canada-ca-asset-upload.s3.amazonaws.com/gov-canada-en-01.png"
+                src="https://assets.notification.canada.ca/gov-canada-en.png"
                 alt="Government of Canada / Gouvernement du Canada"
                 height="30"
                 style="padding-bottom:30px; max-width: 100%; height: auto;"
@@ -47,7 +47,7 @@
                {% if fip_banner_french or brand_name == "canada.ca-fr" %}
 
                <img
-                src="https://notification-alpha-canada-ca-asset-upload.s3.amazonaws.com/09d0d711-9c23-48ec-b21e-fc6acd2412bf-gov-canada-fr.png"
+                src="https://assets.notification.canada.ca/gov-canada-fr.png"
                 alt="Gouvernement du Canada / Government of Canada"
                 height="30"
                 style="padding-bottom:30px; max-width: 100%; height: auto;"
@@ -105,7 +105,7 @@
             </td>
           {% endif %}
         </tr>
-      </table> 
+      </table>
 
       <!-- push content -->
       <table>
@@ -181,13 +181,13 @@
 <!-- so added the min-width: 320 to make sure it looks right on small screens -->
 <table role="presentation" width="100%" style="border-collapse: collapse; min-width: 320px; max-width: 100%; width: 580px; margin: 0 auto;">
   <tr>
-    <td width="100%" bgcolor="#fff" style="width:100%!important; padding: 0;"> 
+    <td width="100%" bgcolor="#fff" style="width:100%!important; padding: 0;">
       <table role="presentation" style="border-collapse: collapse; width: 100%!important; text-align: right;" align="right">
         <tr>
           <td bgcolor="#fff" style="text-align:right;width:100%!important; padding-left: 10px;">
-            <!-- start fip -->  
+            <!-- start fip -->
             <img
-              src="https://cds-notification-assets.s3.ca-central-1.amazonaws.com/wmms-blk.png"
+              src="https://assets.notification.canada.ca/wmms-blk.png"
               alt=" "
               height="25"
               style="padding-top:20px;"

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '43.1.3'
+__version__ = '43.2.0'
 # GDS version '34.0.1'

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -52,9 +52,9 @@ def test_fip_banner_english(show_banner):
     email = HTMLEmailTemplate({'content': 'hello world', 'subject': ''})
     email.fip_banner_english = show_banner
     if show_banner:
-        assert "gov-canada-en-01.png" in str(email)
+        assert "gov-canada-en.png" in str(email)
     else:
-        assert "gov-canada-en-01.png" not in str(email)
+        assert "gov-canada-en.png" not in str(email)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Link images sent in emails on assets.notification.canada.ca instead of using an S3 URL.

Note that emails that have already been sent will use the old URLs and images will still load. Logos have already been migrated to the appropriate S3 bucket

Similar work than on https://github.com/cds-snc/notification-admin/pull/823