### PR TITLE
fix: resolved dependency hell with latest pip resolver upgrade

### DIFF
--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '43.2.1'
+__version__ = '43.2.2'
 # GDS version '34.0.1'

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -21,4 +21,5 @@ function display_result {
 }
 
 # Install Python development dependencies
+python -m pip install --upgrade pip
 pip3 install -r requirements_for_test.txt

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setup(
 
         # required by both api and admin
         'awscli==1.18.188',
-        'boto3==1.16.10',
+        'boto3==1.16.28',
     ]
 )


### PR DESCRIPTION
## Changes

The `pip` tool changed its internal resolver for dependency resolution. The dependency management is stricter and some of our dependencies were found to be in conflict. To know more about these changes, [head over to this blog post](https://pyfound.blogspot.com/2020/11/pip-20-3-new-resolver.html).

For the *notification-utils* project, I simply upgraded the `boto` dependency and made sure it is aligned with the *notification-admin* project.

## Tests

I've cleaned my local virtual environments a few times, used the `--no-cache-dir` of `pip install` as much as I could and reinstall these changes couple of times, referring to my local *notification-utils* project from the *notification-admin* project.