### PR TITLE
Added a statsd_catch annotation to count thrown exceptions

### DIFF
--- a/notifications_utils/statsd_decorators.py
+++ b/notifications_utils/statsd_decorators.py
@@ -68,9 +68,7 @@ def statsd_catch(namespace: str, counter_name: str, exception: Type[Exception]):
             try:
                 return func(*args, **kwargs)
             except exception as e:
-                current_app.statsd_client.incr('{namespace}.{counter_name}'.format(
-                    namespace=namespace, counter_name=counter_name
-                ))
+                current_app.statsd_client.incr(f'{namespace}.{counter_name}')
                 raise e
         wrapper.__wrapped__.__name__ = func.__name__
         return wrapper

--- a/notifications_utils/statsd_decorators.py
+++ b/notifications_utils/statsd_decorators.py
@@ -36,6 +36,32 @@ def statsd(namespace):
 
 
 def statsd_catch(namespace: str, counter_name: str, exception: Type[Exception]):
+    """Increases a statsd counter when a given exception is raised.
+
+    When the expected exception is raised, the statsd counter will be
+    incremented and the initial exception re-raised again.
+
+    When a non-expected exception is raised, no counter increment
+    occurs and nothing is caught: it should go through with no problem.
+
+    All parameters are required.
+
+    Parameters
+    ----------
+    namespace : str, required
+        The statsd counter namespace.
+
+    counter_name : str, required
+        The statsd counter name.
+
+    exception : Type[Exception]
+        The exception to catch and raise the counter upon.
+
+    Raises
+    ------
+    BaseException
+        Any parameter that is thrown by the decorated method.
+    """
     def catch_function(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '43.2.2'
+__version__ = '43.3.0'
 # GDS version '34.0.1'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def rmock():
 @pytest.fixture
 def app_with_statsd(app):
     app.config['NOTIFY_ENVIRONMENT'] = "test"
-    app.config['NOTIFY_APP_NAME'] = "api"
+    app.config['NOTIFY_APP_NAME'] = "utils"
     app.config['STATSD_HOST'] = "localhost"
     app.config['STATSD_PORT'] = "8000"
     app.config['STATSD_PREFIX'] = "prefix"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import pytest
 from flask import Flask
 
 import requests_mock
+from unittest.mock import Mock
 
 
 class FakeService():
@@ -13,7 +14,6 @@ def app():
     flask_app = Flask(__name__)
     ctx = flask_app.app_context()
     ctx.push()
-
     yield flask_app
 
     ctx.pop()
@@ -28,3 +28,14 @@ def sample_service():
 def rmock():
     with requests_mock.mock() as rmock:
         yield rmock
+
+
+@pytest.fixture
+def app_with_statsd(app):
+    app.config['NOTIFY_ENVIRONMENT'] = "test"
+    app.config['NOTIFY_APP_NAME'] = "api"
+    app.config['STATSD_HOST'] = "localhost"
+    app.config['STATSD_PORT'] = "8000"
+    app.config['STATSD_PREFIX'] = "prefix"
+    app.statsd_client = Mock()
+    return app

--- a/tests/test_statsd_decorators.py
+++ b/tests/test_statsd_decorators.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import ANY, Mock
+from unittest.mock import ANY
 from notifications_utils.statsd_decorators import statsd, statsd_catch
 
 
@@ -8,15 +8,8 @@ class AnyStringWith(str):
         return self in other
 
 
-def test_should_call_statsd(app, mocker):
-    app.config['NOTIFY_ENVIRONMENT'] = "test"
-    app.config['NOTIFY_APP_NAME'] = "api"
-    app.config['STATSD_HOST'] = "localhost"
-    app.config['STATSD_PORT'] = "8000"
-    app.config['STATSD_PREFIX'] = "prefix"
-    app.statsd_client = Mock()
-
-    mock_logger = mocker.patch.object(app.logger, 'debug')
+def test_should_call_statsd(app_with_statsd, mocker):
+    mock_logger = mocker.patch.object(app_with_statsd.logger, 'debug')
 
     @statsd(namespace="test")
     def test_function():
@@ -24,8 +17,8 @@ def test_should_call_statsd(app, mocker):
 
     assert test_function()
     mock_logger.assert_called_once_with(AnyStringWith("test call test_function took "))
-    app.statsd_client.incr.assert_called_once_with("test.test_function")
-    app.statsd_client.timing.assert_called_once_with("test.test_function", ANY)
+    app_with_statsd.statsd_client.incr.assert_called_once_with("test.test_function")
+    app_with_statsd.statsd_client.timing.assert_called_once_with("test.test_function", ANY)
 
 
 def test_should_call_statsd_catch(app_with_statsd, mocker):

--- a/tests/test_statsd_decorators.py
+++ b/tests/test_statsd_decorators.py
@@ -1,5 +1,6 @@
+import pytest
 from unittest.mock import ANY, Mock
-from notifications_utils.statsd_decorators import statsd
+from notifications_utils.statsd_decorators import statsd, statsd_catch
 
 
 class AnyStringWith(str):
@@ -25,3 +26,56 @@ def test_should_call_statsd(app, mocker):
     mock_logger.assert_called_once_with(AnyStringWith("test call test_function took "))
     app.statsd_client.incr.assert_called_once_with("test.test_function")
     app.statsd_client.timing.assert_called_once_with("test.test_function", ANY)
+
+
+def test_should_call_statsd_catch(app_with_statsd, mocker):
+    class CustomException(BaseException):
+        pass
+
+    class FooBar():
+        @statsd_catch(namespace="test", counter_name="rate.test", exception=CustomException)
+        def test_function(self):
+            return True
+
+    fb = FooBar()
+    mocker.spy(fb, 'test_function')
+
+    assert fb.test_function()
+    fb.test_function.assert_called_once()
+    app_with_statsd.statsd_client.incr.assert_not_called()
+
+
+def test_should_incr_statsd_on_catch(app_with_statsd, mocker):
+    class CustomException(BaseException):
+        pass
+
+    class FooBar():
+        @statsd_catch(namespace="test", counter_name="rate.test", exception=CustomException)
+        def test_function(self):
+            raise CustomException("huh huh")
+
+    fb = FooBar()
+    mocker.spy(fb, 'test_function')
+
+    with pytest.raises(CustomException):
+        fb.test_function()
+    fb.test_function.assert_called_once()
+    app_with_statsd.statsd_client.incr.assert_called_once_with("test.rate.test")
+
+
+def test_should_not_incr_statsd_on_catch_and_non_matching_exception(app_with_statsd, mocker):
+    class CustomException(BaseException):
+        pass
+
+    class FooBar():
+        @statsd_catch(namespace="test", counter_name="rate.test", exception=AssertionError)
+        def test_function(self):
+            raise CustomException("huh huh")
+
+    fb = FooBar()
+    mocker.spy(fb, 'test_function')
+
+    with pytest.raises(CustomException):
+        fb.test_function()
+    fb.test_function.assert_called_once()
+    app_with_statsd.statsd_client.incr.assert_not_called()


### PR DESCRIPTION
## Issue

https://trello.com/c/62gscLJH/169-graph-the-services-going-over-the-daily-rate-limit

## Changes

For improving our coverage of statsd metric, a `statsd_catch` annotation will increment a counter based on given namespace and counter name **when** the defined exception is raised

## Context

This will immediately be useful to send statsd metrics with the daily rate limit.

## Testing 

* Mostly unit tests in the context of the *notification-utils* project.