### PR TITLE
Reverse arguments for timing_with_dates

### DIFF
--- a/notifications_utils/clients/statsd/statsd_client.py
+++ b/notifications_utils/clients/statsd/statsd_client.py
@@ -79,7 +79,7 @@ class StatsdClient():
         if self.active:
             self.statsd_client.timing(self.format_stat_name(stat), delta, rate)
 
-    def timing_with_dates(self, stat, start, end, rate=1):
+    def timing_with_dates(self, stat, end, start, rate=1):
         if self.active:
-            delta = (start - end).total_seconds()
+            delta = (end - start).total_seconds()
             self.statsd_client.timing(self.format_stat_name(stat), delta, rate)

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '43.5.0'
+__version__ = '43.5.1'
 # GDS version '34.0.1'


### PR DESCRIPTION
Those were confusing, the first argument should be in the future but it was named `start`. Renaming variables.