### PR TITLE
Record StatsD stats with and without service IDs

### DIFF
--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '43.5.1'
+__version__ = '43.6.0'
 # GDS version '34.0.1'


### PR DESCRIPTION
We want to be able to have metrics for HTTP endpoints when requests are successful and we have a `service_id`. At the moment we have only timers/counters per service but we something without a service ID is needed if we want to use stats for some endpoints.

We need this to compute SLOs for example, we are interested in stats for specific endpoints
```
POST /v2/notifications/email (sending an email)
POST /v2/notifications/sms (sending an SMS)
GET /v2/notifications (getting the status of a notification)
```

There were no tests covering recording stats so I've added one.

![Screen Shot 2021-04-19 at 12 07 20](https://user-images.githubusercontent.com/295709/115268739-94038100-a108-11eb-98cd-415390559a01.png)
