### PR TITLE
feat: better list item style for Outlook

### DIFF
--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -17,6 +17,11 @@
     body { margin:0 !important; }
     div[style*="margin: 16px 0"] { margin:0 !important; }
   </style>
+  <!--[if gte mso 9]>
+  <style>
+     li {text-indent: -1em;}
+  </style>
+  <![endif]-->
 </head>
 
 <body style="font-family: Helvetica, Arial, sans-serif;font-size: 16px;margin: 0;color:#0b0c0c;">

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '43.6.0'
+__version__ = '43.7.0'
 # GDS version '34.0.1'


### PR DESCRIPTION
We got reports that list items were cut off on Outlook. Seems to [be common](https://uplandsoftware.com/postup/resources/blog/solutions-for-bullet-points-that-shrink-or-disappear-in-outlook/).

Implemented some recommended HTML fixes found here:
- https://litmus.com/community/discussions/1093-bulletproof-lists-using-ul-and-li
- https://stackoverflow.com/questions/57142744/html-tags-ul-li-not-working-in-windows-outlook

Tested this by sending an email to myself using the AWS Console and looking at it on Gmail + on Outlook Office 365. Checked before that the bug was present on Outlook Office 365 as well.