### PR TITLE
Bump version to 43.8.0

### DIFF
--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '43.7.0'
+__version__ = '43.8.0'
 # GDS version '34.0.1'


### PR DESCRIPTION
I did not upgrade the version in https://github.com/cds-snc/notification-utils/pull/79, or in fact I kept the old version but merged #80 before. Sorry about that.