### PR TITLE
feat: add bold, italic and h2 header

### DIFF
--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -365,7 +365,7 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
             )
         elif level == 2:
             return (
-                '<h3 style="Margin: 0 0 15px 0; padding: 0; line-height: 26px; color: #323A45;'
+                '<h3 style="Margin: 0 0 15px 0; padding: 0; line-height: 26px; color: #0B0C0C;'
                 'font-size: 24px; font-weight: bold;">'
                 f'{text}'
                 '</h3>'

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -360,10 +360,15 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
             return (
                 '<h2 style="Margin: 0 0 20px 0; padding: 0; '
                 'font-size: 27px; line-height: 35px; font-weight: bold; color: #0B0C0C;">'
-                '{}'
+                f'{text}'
                 '</h2>'
-            ).format(
-                text
+            )
+        elif level == 2:
+            return (
+                '<h3 style="Margin: 0 0 15px 0; padding: 0; line-height: 26px; color: #323A45;'
+                'font-size: 24px; font-weight: bold;">'
+                f'{text}'
+                '</h3>'
             )
         return self.paragraph(text)
 
@@ -456,10 +461,10 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
         )
 
     def double_emphasis(self, text):
-        return '**{}**'.format(text)
+        return f"<strong>{text}</strong>"
 
     def emphasis(self, text):
-        return '*{}*'.format(text)
+        return f"<em>{text}</em>"
 
 
 class NotifyPlainTextEmailMarkdownRenderer(NotifyEmailMarkdownRenderer):
@@ -473,6 +478,13 @@ class NotifyPlainTextEmailMarkdownRenderer(NotifyEmailMarkdownRenderer):
                 text,
                 self.linebreak(),
                 '-' * self.COLUMN_WIDTH,
+            ))
+        elif level == 2:
+            return ''.join((
+                self.linebreak() * 2,
+                text,
+                self.linebreak(),
+                '-' * self.COLUMN_WIDTH
             ))
         return self.paragraph(text)
 
@@ -528,6 +540,12 @@ class NotifyPlainTextEmailMarkdownRenderer(NotifyEmailMarkdownRenderer):
 
     def autolink(self, link, is_email=False):
         return link
+
+    def double_emphasis(self, text):
+        return f"**{text}**"
+
+    def emphasis(self, text):
+        return f"_{text}_"
 
 
 class NotifyEmailPreheaderMarkdownRenderer(NotifyPlainTextEmailMarkdownRenderer):

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -60,9 +60,8 @@ def init_app(app, statsd_client=None):
             })
 
         if 'start' in g:
-            time_taken = monotonic() - g.start
             extra_fields.update({
-                'time_taken': "%.5f" % time_taken
+                'time_taken': (monotonic() - g.start) * 1000
             })
 
         if 'endpoint' in g:
@@ -70,7 +69,7 @@ def init_app(app, statsd_client=None):
                 'endpoint': g.endpoint
             })
 
-        record_stats(statsd_client, extra_fields, time_taken)
+        record_stats(statsd_client, extra_fields)
 
         return response
 
@@ -90,7 +89,7 @@ def init_app(app, statsd_client=None):
     app.logger.info("Logging configured")
 
 
-def record_stats(statsd_client, extra_fields, time_taken):
+def record_stats(statsd_client, extra_fields):
     if not statsd_client:
         return
     stats = [build_statsd_line(extra_fields)]
@@ -104,7 +103,7 @@ def record_stats(statsd_client, extra_fields, time_taken):
         statsd_client.incr(stat)
 
         if 'time_taken' in extra_fields:
-            statsd_client.timing(stat, time_taken)
+            statsd_client.timing(stat, extra_fields['time_taken'])
 
 
 def ensure_log_path_exists(path):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '43.7.0'
+__version__ = '43.9.0'
 # GDS version '34.0.1'

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -320,7 +320,7 @@ def test_level_1_header(markdown_function, heading, expected):
     ],
     [
         notify_email_markdown,
-        '<h3 style="Margin: 0 0 15px 0; padding: 0; line-height: 26px; color: #323A45;'
+        '<h3 style="Margin: 0 0 15px 0; padding: 0; line-height: 26px; color: #0B0C0C;'
         'font-size: 24px; font-weight: bold;">inset text</h3>'
     ],
     [

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -320,13 +320,15 @@ def test_level_1_header(markdown_function, heading, expected):
     ],
     [
         notify_email_markdown,
-        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">inset text</p>'
+        '<h3 style="Margin: 0 0 15px 0; padding: 0; line-height: 26px; color: #323A45;'
+        'font-size: 24px; font-weight: bold;">inset text</h3>'
     ],
     [
         notify_plain_text_email_markdown,
         (
             '\n'
             '\ninset text'
+            '\n-----------------------------------------------------------------'
         ),
     ],
 ))
@@ -683,16 +685,18 @@ def test_codespan(markdown_function, expected):
     ],
     [
         notify_email_markdown,
-        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">something **important**</p>'
+        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">'
+        'something <strong>important</strong></p>'
     ],
     [
         notify_plain_text_email_markdown,
         '\n\nsomething **important**',
     ],
 ))
-def test_double_emphasis(markdown_function, expected):
+@pytest.mark.parametrize('emphasis_style', ['**', '__'])
+def test_double_emphasis(markdown_function, expected, emphasis_style):
     assert markdown_function(
-        'something **important**'
+        f'something {emphasis_style}important{emphasis_style}'
     ) == expected
 
 
@@ -703,32 +707,35 @@ def test_double_emphasis(markdown_function, expected):
     ],
     [
         notify_email_markdown,
-        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">something *important*</p>'
+        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">'
+        'something <em>important</em></p>'
     ],
     [
         notify_plain_text_email_markdown,
-        '\n\nsomething *important*',
+        '\n\nsomething _important_',
     ],
 ))
-def test_emphasis(markdown_function, expected):
+@pytest.mark.parametrize('emphasis_style', ['_', '*'])
+def test_emphasis(markdown_function, expected, emphasis_style):
     assert markdown_function(
-        'something *important*'
+        f'something {emphasis_style}important{emphasis_style}'
     ) == expected
 
 
 @pytest.mark.parametrize('markdown_function, expected', (
     [
         notify_email_markdown,
-        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">foo ****** bar</p>'
+        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">'
+        'foo <strong><em>bar</em></strong></p>'
     ],
     [
         notify_plain_text_email_markdown,
-        '\n\nfoo ****** bar',
+        '\n\nfoo **_bar_**',
     ],
 ))
 def test_nested_emphasis(markdown_function, expected):
     assert markdown_function(
-        'foo ****** bar'
+        'foo **_bar_**'
     ) == expected
 
 


### PR DESCRIPTION
Add bold, italic and h2 header to email templates.

Looked at how Veteran Affairs did it in the US
- https://github.com/department-of-veterans-affairs/notification-utils/commit/fc4e518ab2e86dbd36dc5cc8f11b638746d83e11
- https://github.com/department-of-veterans-affairs/notification-utils/commit/38700405b2c56e2d680b54b30dc3e4f6d091da17

![Screen Shot 2021-05-04 at 10 57 56](https://user-images.githubusercontent.com/295709/117027595-d90fe180-acca-11eb-803d-9830896bb8ab.png)

TODO: pull it this new version on admin and API. ⚠️ does not have a CSS rule for `<strong>` yet