### PR TITLE
fix: avoid confusion between list and bold

### DIFF
--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -26,7 +26,7 @@ OBSCURE_WHITESPACE = (
 mistune._block_quote_leading_pattern = re.compile(r'^ *\^ ?', flags=re.M)
 mistune.BlockGrammar.block_quote = re.compile(r'^( *\^[^\n]+(\n[^\n]+)*\n*)+')
 mistune.BlockGrammar.list_block = re.compile(
-    r'^( *)([•*-]|\d+\.)[\s\S]+?'
+    r'^( *)([•*-]|\d+\.)[^*][\s\S]+?'
     r'(?:'
     r'\n+(?=\1?(?:[-*_] *){3,}(?:\n+|$))'  # hrule
     r'|\n+(?=%s)'  # def links

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '43.9.0'
+__version__ = '43.9.1'
 # GDS version '34.0.1'

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -534,6 +534,33 @@ def test_pluses_dont_render_as_lists(markdown_function, expected):
     ) == expected
 
 
+@pytest.mark.parametrize('markdown_function, input, expected', (
+    [
+        notify_email_markdown,
+        '**title**: description',
+        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">'
+        '<strong>title</strong>: description</p>'
+    ],
+    [
+        notify_email_markdown,
+        '**_title_**: description',
+        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">'
+        '<strong><em>title</em></strong>: description</p>'
+    ],
+    [
+        notify_email_markdown,
+        '* **title**: description',
+        '<table role="presentation" style="padding: 0 0 20px 0;">'
+        '<tr><td style="font-family: Helvetica, Arial, sans-serif;">'
+        '<ul style="Margin: 0 0 0 20px; padding: 0; list-style-type: disc;">'
+        '<li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px;line-height: 25px; color: #0B0C0C;">'
+        '<strong>title</strong>: description</li></ul></td></tr></table>'
+    ],
+))
+def test_list_and_bold_or_italic(markdown_function, input, expected):
+    assert markdown_function(input) == expected
+
+
 @pytest.mark.parametrize('markdown_function, expected', (
     [
         notify_letter_preview_markdown,


### PR DESCRIPTION
At the moment, using `**` at the beginning of the list does not work as intended, it tries to create multiple list items.

```
# h1
## h2

_italic_ and **bold**

**Title**: test
```

renders like

![Screen Shot 2021-05-17 at 10 18 05](https://user-images.githubusercontent.com/295709/118504057-30fe0d80-b6f9-11eb-9820-742a38bb28fd.png)

This is because we have a custom regex, allowing lists to not have a space after an initial `*`. The original library does not have that (it's not standard Markdown)
https://github.com/lepture/mistune/blob/6470c42b2087a4649ad0437227cf7b5c570c3a91/mistune.py#L121, the relevant part is ` [\s\S]+?` (space before `[\s\S]+?`)

Tweaked the regex to make sure we don't match `**` as the start of a list. There are no regressions for other list tests in `test_formatters.py`

Trello: https://trello.com/c/22a6eKqK/513-fix-confusion-between-bold-and-lists