### PR TITLE
Show logos in email previews

### DIFF
--- a/notifications_utils/jinja_templates/email_preview_template.jinja2
+++ b/notifications_utils/jinja_templates/email_preview_template.jinja2
@@ -1,5 +1,5 @@
-<div class="email-message mb-12 border border-solid border-gray-grey2">
-  <table class="email-message-meta m-0 text-smaller leading-tight font-normal">
+<div class="email-message mb-12">
+  <table class="email-message-meta mb-12 leading-tight font-normal border border-solid border-gray-grey2">
     <tbody>
       {% if show_recipient %}
         {% if from_name %}
@@ -33,7 +33,60 @@
       </tr>
     </tbody>
   </table>
-  <div class="email-message-body w-full m-0 relative break-words clear-both box-border px-doubleGutter pt-gutterHalf pb-0">
-    {{ body }}
+
+  <div class="email-message-body w-full m-0 relative break-words clear-both box-border px-doubleGutter py-4 border-gray-grey2 border">
+
+    <div style="max-width: 580px; margin: 0 auto">
+      {% if fip_banner_english %}
+        <div style="max-width: 326px">
+          <img
+            src="https://{{ asset_domain }}/gov-canada-en.png"
+            alt="Government of Canada / Gouvernement du Canada"
+            height="30"
+            style="padding-bottom:30px; max-width: 100%; height: auto;"
+          />
+        </div>
+      {% endif %}
+
+      {% if fip_banner_french or brand_name == "canada.ca-fr" %}
+        <div style="max-width: 326px">
+          <img
+            src="https://{{ asset_domain }}/gov-canada-fr.png"
+            alt="Gouvernement du Canada / Government of Canada"
+            height="30"
+            style="padding-bottom:30px; max-width: 100%; height: auto;"
+          />
+        </div>
+      {% endif %}
+
+      {% if brand_logo %}
+        <div style="padding: 0 5px 0 {% if brand_colour %} 8px; border-left: solid 2px {{ brand_colour }}{% else %} 10px{% endif %}; display: inline-block">
+        <img
+          src="https://{{ asset_domain }}/{{ brand_logo }}"
+          style="padding-left:0; display: block; border: 0; height:{% if brand_text -%} 27 {%- else -%} 108 {%- endif %}px"
+          alt="{% if brand_text %} {% else -%}{{ brand_name }}{%- endif %}"
+        />
+        </div>
+
+        <p style="font-family: Helvetica, Arial, sans-serif; font-size: 18px; line-height: 23px; display: inline-block">
+          {% if brand_text %}
+          {{ brand_text }}
+          {% endif %}
+        </p>
+      {% endif %}
+
+      {{ body }}
+
+      {% if fip_banner_english or fip_banner_french or brand_name == "canada.ca-fr" %}
+        <div>
+          <img
+            src="https://{{ asset_domain }}/wmms-blk.png"
+            alt=" "
+            style="padding-top:20px; float: right; height: 45px"
+          />
+        </div>
+        <div style="clear:both;"></div>
+      {% endif %}
+    </div>
   </div>
 </div>

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -411,6 +411,14 @@ class EmailPreviewTemplate(WithSubjectTemplate):
         show_recipient=True,
         redact_missing_personalisation=False,
         jinja_path=None,
+        fip_banner_english=None,
+        fip_banner_french=None,
+        brand_colour=None,
+        brand_logo=None,
+        brand_text=None,
+        brand_name=None,
+        logo_with_background_colour=None,
+        asset_domain=None,
     ):
         super().__init__(template,
                          values,
@@ -421,6 +429,13 @@ class EmailPreviewTemplate(WithSubjectTemplate):
         self.reply_to = reply_to
         self.show_recipient = show_recipient
         self.jinja_template = self.template_env.get_template('email_preview_template.jinja2')
+        self.fip_banner_english = fip_banner_english
+        self.fip_banner_french = fip_banner_french
+        self.brand_colour = brand_colour
+        self.brand_logo = brand_logo
+        self.brand_text = brand_text
+        self.brand_name = brand_name
+        self.asset_domain = asset_domain or "assets.notification.canada.ca"
 
     def __str__(self):
         return Markup(self.jinja_template.render({
@@ -432,7 +447,14 @@ class EmailPreviewTemplate(WithSubjectTemplate):
             'from_address': self.from_address,
             'reply_to': self.reply_to,
             'recipient': Field("((email address))", self.values, translated=True),
-            'show_recipient': self.show_recipient
+            'show_recipient': self.show_recipient,
+            'fip_banner_english': self.fip_banner_english,
+            'fip_banner_french': self.fip_banner_french,
+            'brand_colour': self.brand_colour,
+            'brand_logo': self.brand_logo,
+            'brand_text': self.brand_text,
+            'brand_name': self.brand_name,
+            'asset_domain': self.asset_domain,
         }))
 
     @property

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = '43.9.1'
+__version__ = '43.10.0'
 # GDS version '34.0.1'


### PR DESCRIPTION
Show logos in email previews on the admin.

Supports:
- FIP EN
- FIP FR
- custom logo with URL
- custom logo with URL and text

Most of the Jinja code is stolen from the [email Jinja template](https://github.com/cds-snc/notification-utils/blob/master/notifications_utils/jinja_templates/email_template.jinja2) but simplified because we don't need tables for the web.

I've reused a lot of tests to prove that things are displayed as expected.

![image](https://user-images.githubusercontent.com/295709/118537020-6c5d0400-b71a-11eb-89e0-e09a88020303.png)

Admin PR pulling in this change: https://github.com/cds-snc/notification-admin/pull/1026
