### PR TITLE
Added alt text to the Canada Wordmark

### DIFF
--- a/notifications_utils/jinja_templates/email_preview_template.jinja2
+++ b/notifications_utils/jinja_templates/email_preview_template.jinja2
@@ -83,7 +83,7 @@
         <div style="margin: 10px 0 20px 0; float: right">
           <img
             src="https://{{ asset_domain }}/canada-logo.png"
-            alt=" "
+            alt="Symbol of the Government of Canada / Symbole du gouvernement du Canada"
             height="55"
             width="123"
           />

--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -174,7 +174,7 @@
           <td style="line-height: 0px; border: 0; padding: 0">
             <img
               src="https://assets.notification.canada.ca/canada-logo.png?20210531"
-              alt=" "
+              alt="Symbol of the Government of Canada / Symbole du gouvernement du Canada"
               width="123"
               height="55"
               border="0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,7 @@
 [tool:pytest]
 xfail_strict=true
+testpaths = tests
+addopts = -p no:warnings -n4
 
 [flake8]
 # W504 line break after binary operator

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -160,7 +160,7 @@ def test_alt_text_with_no_brand_text_and_fip_banner_english_shown(renderer):
             brand_name="Notify Logo",
         )
     )
-    assert 'alt=" "' in email
+    assert 'alt="Symbol of the Government of Canada / Symbole du gouvernement du Canada"' in email
     assert 'alt="Notify Logo"' in email
 
 
@@ -177,7 +177,7 @@ def test_alt_text_with_no_brand_text_and_fip_banner_french_shown(renderer):
             brand_name="Notify Logo",
         )
     )
-    assert 'alt=" "' in email
+    assert 'alt="Symbol of the Government of Canada / Symbole du gouvernement du Canada"' in email
     assert 'alt="Notify Logo"' in email
 
 


### PR DESCRIPTION
# Summary | Résumé

~I will convert from draft after I fix the tests.~ Fixed

I noticed that there was no alt text for the Canada wordmark inserted at the bottom of Notify emails, so screen readers read nothing for this. I looked at Canada.ca and copied the english and french alt text from there:

<img width="959" alt="Screen Shot 2021-07-09 at 4 31 26 PM" src="https://user-images.githubusercontent.com/5498428/125133941-cdbea500-e0c3-11eb-8887-6f5153dc50de.png">

<img width="961" alt="Screen Shot 2021-07-09 at 4 33 37 PM" src="https://user-images.githubusercontent.com/5498428/125133966-d57e4980-e0c3-11eb-9c52-d5db8ae82931.png">

