### PR TITLE
MyPy "check untyped definitions"

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 python_version = 3.9
+check_untyped_defs = True
 
 [mypy-orderedset.*]
 ignore_missing_imports = True

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -1,7 +1,7 @@
 import numbers
 import uuid
 from time import time
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from flask_redis import FlaskRedis
 from flask import current_app

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -1,7 +1,7 @@
 import numbers
 import uuid
 from time import time
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from flask_redis import FlaskRedis
 from flask import current_app
@@ -196,12 +196,12 @@ class RedisClient:
                 self.__handle_exception(e, raise_exception, "expire", key)
 
     def delete(self, *keys, raise_exception=False):
-        keys = [prepare_value(k) for k in keys]
+        _keys = [prepare_value(k) for k in keys]
         if self.active:
             try:
-                self.redis_store.delete(*keys)
+                self.redis_store.delete(*_keys)
             except Exception as e:
-                self.__handle_exception(e, raise_exception, "delete", ", ".join(keys))
+                self.__handle_exception(e, raise_exception, "delete", ", ".join(_keys))
 
     def __handle_exception(self, e, raise_exception, operation, key_name):
         current_app.logger.exception("Redis error performing {} on {}".format(operation, key_name))

--- a/notifications_utils/clients/statsd/statsd_client.py
+++ b/notifications_utils/clients/statsd/statsd_client.py
@@ -64,17 +64,17 @@ class StatsdClient:
 
     def incr(self, stat, count=1, rate=1):
         if self.active:
-            self.statsd_client.incr(self.format_stat_name(stat), count, rate)
+            self.statsd_client.incr(self.format_stat_name(stat), count, rate)  # type: ignore
 
     def gauge(self, stat, count):
         if self.active:
-            self.statsd_client.gauge(self.format_stat_name(stat), count)
+            self.statsd_client.gauge(self.format_stat_name(stat), count)  # type: ignore
 
     def timing(self, stat, delta, rate=1):
         if self.active:
-            self.statsd_client.timing(self.format_stat_name(stat), delta, rate)
+            self.statsd_client.timing(self.format_stat_name(stat), delta, rate)  # type: ignore
 
     def timing_with_dates(self, stat, end, start, rate=1):
         if self.active:
             delta = (end - start).total_seconds()
-            self.statsd_client.timing(self.format_stat_name(stat), delta, rate)
+            self.statsd_client.timing(self.format_stat_name(stat), delta, rate)  # type: ignore

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -49,18 +49,6 @@ class Placeholder:
         return "Placeholder({})".format(self.body)
 
 
-def get_sanitizer(method) -> Callable:
-    if method == "strip":
-        return strip_html
-    elif method == "escape":
-        return escape_html
-    elif method == "passthrough":
-        return str
-    elif method == "strip_dvla_markup":
-        return strip_dvla_markup
-    raise Exception(f"Invalid sanitizer method specified: {method}")
-
-
 class Field:
     placeholder_pattern = re.compile(
         r"\({2}" r"([^()]+)" r"\){2}"  # opening ((  # body of placeholder - potentially standard or conditional.  # closing ))
@@ -79,7 +67,7 @@ class Field:
         if translated:
             self.placeholder_tag = self.placeholder_tag_translated
 
-        self.sanitizer = get_sanitizer(html)
+        self.sanitizer = self.get_sanitizer(html)
         self.redact_missing_personalisation = redact_missing_personalisation
 
     def __str__(self):
@@ -89,6 +77,18 @@ class Field:
 
     def __repr__(self):
         return '{}("{}", {})'.format(self.__class__.__name__, self.content, self.values)  # TODO: more real
+
+    @staticmethod
+    def get_sanitizer(method: str) -> Callable:
+        if method == "strip":
+            return strip_html
+        elif method == "escape":
+            return escape_html
+        elif method == "passthrough":
+            return str
+        elif method == "strip_dvla_markup":
+            return strip_dvla_markup
+        raise Exception(f"Invalid sanitizer method specified: {method}")
 
     @property
     def values(self):

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -1,5 +1,5 @@
 import re
-from typing import Any, Callable, List
+from typing import Any, Callable, Dict, List
 
 from orderedset import OrderedSet
 from flask import Markup
@@ -80,15 +80,13 @@ class Field:
 
     @staticmethod
     def get_sanitizer(method: str) -> Callable:
-        if method == "strip":
-            return strip_html
-        elif method == "escape":
-            return escape_html
-        elif method == "passthrough":
-            return str
-        elif method == "strip_dvla_markup":
-            return strip_dvla_markup
-        raise Exception(f"Invalid sanitizer method specified: {method}")
+        sanitizers: Dict[str, Callable] = {
+            "strip": strip_html,
+            "escape": escape_html,
+            "passthrough": str,
+            "strip_dvla_markup": strip_dvla_markup,
+        }
+        return sanitizers[method]
 
     @property
     def values(self):

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -156,7 +156,7 @@ class RequestIdFilter(logging.Filter):
     @property
     def request_id(self):
         if has_request_context() and hasattr(request, "request_id"):
-            return request.request_id
+            return request.request_id  # type: ignore
         else:
             return "no-request-id"
 
@@ -172,6 +172,8 @@ class CustomLogFormatter(logging.Formatter):
     FORMAT_STRING_FIELDS_PATTERN = re.compile(r"\((.+?)\)", re.IGNORECASE)
 
     def add_fields(self, record):
+        if self._fmt is None:
+            raise Exception("self._fmt is None")
         for field in self.FORMAT_STRING_FIELDS_PATTERN.findall(self._fmt):
             record.__dict__[field] = record.__dict__.get(field)
         return record

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -173,7 +173,7 @@ class CustomLogFormatter(logging.Formatter):
 
     def add_fields(self, record):
         if self._fmt is None:
-            raise Exception("self._fmt is None")
+            raise TypeError("self._fmt is None")
         for field in self.FORMAT_STRING_FIELDS_PATTERN.findall(self._fmt):
             record.__dict__[field] = record.__dict__.get(field)
         return record

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -1,7 +1,7 @@
 import re
 import sys
 import csv
-from typing import Callable
+from typing import Callable, List
 import phonenumbers
 import os
 from io import StringIO
@@ -10,7 +10,6 @@ from functools import lru_cache, partial
 from itertools import islice
 from collections import OrderedDict, namedtuple
 from orderedset import OrderedSet
-from typing import List
 
 from flask import current_app
 

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -1,6 +1,7 @@
 import re
 import sys
 import csv
+from typing import Callable
 import phonenumbers
 import os
 from io import StringIO
@@ -472,12 +473,19 @@ def validate_address(address_line, column):
     return address_line
 
 
+def get_validator(template_type: str, international_sms: bool) -> Callable:
+    if template_type == "email":
+        return validate_email_address
+    elif template_type == "sms":
+        return partial(validate_phone_number, international=international_sms)
+    elif template_type == "letter":
+        return validate_address
+    raise Exception(f"invalid template type: {template_type}")
+
+
 def validate_recipient(recipient, template_type, column=None, international_sms=False):
-    return {
-        "email": validate_email_address,
-        "sms": partial(validate_phone_number, international=international_sms),
-        "letter": validate_address,
-    }[template_type](recipient, column)
+    validator = get_validator(template_type, international_sms)
+    return validator(recipient, column)
 
 
 @lru_cache(maxsize=32, typed=False)

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -10,6 +10,7 @@ from functools import lru_cache, partial
 from itertools import islice
 from collections import OrderedDict, namedtuple
 from orderedset import OrderedSet
+from typing import List
 
 from flask import current_app
 
@@ -99,7 +100,7 @@ class RecipientCSV:
     @placeholders.setter
     def placeholders(self, value):
         try:
-            self._placeholders = list(value) + self.recipient_column_headers
+            self._placeholders: List[str] = list(value) + self.recipient_column_headers
         except TypeError:
             self._placeholders = self.recipient_column_headers
         self.placeholders_as_column_keys = [Columns.make_key(placeholder) for placeholder in self._placeholders]

--- a/notifications_utils/request_helper.py
+++ b/notifications_utils/request_helper.py
@@ -64,10 +64,10 @@ class ResponseHeaderMiddleware(object):
             lower_existing_header_names = frozenset(name.lower() for name, value in headers)
 
             if self.trace_id_header not in lower_existing_header_names:
-                headers.append((self.trace_id_header, str(request.trace_id)))
+                headers.append((self.trace_id_header, str(request.trace_id)))  # type: ignore
 
             if self.span_id_header not in lower_existing_header_names:
-                headers.append((self.span_id_header, str(request.span_id)))
+                headers.append((self.span_id_header, str(request.span_id)))  # type: ignore
 
             return start_response(status, headers, exc_info)
 

--- a/notifications_utils/statsd_decorators.py
+++ b/notifications_utils/statsd_decorators.py
@@ -28,7 +28,7 @@ def statsd(namespace):
                 )
                 return res
 
-        wrapper.__wrapped__.__name__ = func.__name__
+        wrapper.__wrapped__.__name__ = func.__name__  # type: ignore
         return wrapper
 
     return time_function
@@ -71,7 +71,7 @@ def statsd_catch(namespace: str, counter_name: str, exception: Type[Exception]):
                 current_app.statsd_client.incr(f"{namespace}.{counter_name}")
                 raise e
 
-        wrapper.__wrapped__.__name__ = func.__name__
+        wrapper.__wrapped__.__name__ = func.__name__  # type: ignore
         return wrapper
 
     return catch_function

--- a/tests/test_statsd_client.py
+++ b/tests/test_statsd_client.py
@@ -98,7 +98,7 @@ def test_should_call_gauge_if_enabled(enabled_statsd_client):
 def test_should_log_but_not_throw_if_socket_errors(app, mocker):
     stats_client = NotifyStatsClient("localhost", 8125, "")
     mocker.patch.object(stats_client, "_sock")
-    stats_client._sock.sendto = Mock(side_effect=Exception("Mock Exception"))
+    stats_client._sock.sendto = Mock(side_effect=Exception("Mock Exception"))  # type: ignore
     mock_logger = mocker.patch("flask.Flask.logger")
 
     stats_client._send("data")

--- a/tests/test_statsd_decorators.py
+++ b/tests/test_statsd_decorators.py
@@ -22,7 +22,7 @@ def test_should_call_statsd(app_with_statsd, mocker):
 
 
 def test_should_call_statsd_catch(app_with_statsd, mocker):
-    class CustomException(BaseException):
+    class CustomException(Exception):
         pass
 
     class FooBar:
@@ -39,7 +39,7 @@ def test_should_call_statsd_catch(app_with_statsd, mocker):
 
 
 def test_should_incr_statsd_on_catch(app_with_statsd, mocker):
-    class CustomException(BaseException):
+    class CustomException(Exception):
         pass
 
     class FooBar:

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -2029,6 +2029,8 @@ def test_nested_lists_in_lettr_markup():
 
 def test_that_print_template_is_the_same_as_preview():
     assert dir(LetterPreviewTemplate) == dir(LetterPrintTemplate)
+    assert LetterPreviewTemplate.jinja_template.filename
+    assert LetterPrintTemplate.jinja_template.filename
     assert os.path.basename(LetterPreviewTemplate.jinja_template.filename) == "preview.jinja2"
     assert os.path.basename(LetterPrintTemplate.jinja_template.filename) == "print.jinja2"
 


### PR DESCRIPTION
# Summary | Résumé

Adding `check_untyped_defs = True` to the mypy config file tells mypy check inside functions without type definitions (https://mypy.readthedocs.io/en/stable/config_file.html#confval-check_untyped_defs). This helps catch more errors. I'm starting with this repo since it is smaller and less of a lift to fix/ignore the existing errors.