### PR TITLE
Bump version from 44.0.0 to 44.1.0

### DIFF
--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = "44.0.0"
+__version__ = "44.1.0"
 # GDS version '34.0.1'


### PR DESCRIPTION
Bumping version from 44.0.0 to 44.1.0

# Summary | Résumé

Added a couple of functions which were merged but I forgot to bump up the version to create a release
