### PR TITLE
Adding MyPy check to run_tests.sh

### DIFF
--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -59,7 +59,13 @@ class Field:
     placeholder_tag_redacted = "<span class='placeholder-redacted'>[hidden]</span>"
 
     def __init__(
-        self, content, values=None, html="strip", markdown_lists=False, redact_missing_personalisation=False, translated=False
+        self,
+        content: str,
+        values: Dict[str, Any] = None,
+        html: str = "strip",
+        markdown_lists: bool = False,
+        redact_missing_personalisation: bool = False,
+        translated: bool = False,
     ):
         self.content = content
         self.values = values

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -28,6 +28,9 @@ display_result $? 1 "Code style check (Black)"
 flake8 .
 display_result $? 1 "Code style check"
 
+mypy .
+display_result $? 1 "Static type check"
+
 ## Code coverage
 #py.test --cov=client tests/
 #display_result $? 2 "Code coverage"

--- a/setup.py
+++ b/setup.py
@@ -6,41 +6,39 @@ import ast
 from setuptools import setup, find_packages
 
 
-_version_re = re.compile(r'__version__\s+=\s+(.*)')
+_version_re = re.compile(r"__version__\s+=\s+(.*)")
 
-with open('notifications_utils/version.py', 'rb') as f:
-    version = str(ast.literal_eval(_version_re.search(
-        f.read().decode('utf-8')).group(1)))
+with open("notifications_utils/version.py", "rb") as f:
+    version = str(ast.literal_eval(_version_re.search(f.read().decode("utf-8")).group(1)))  # type: ignore
 
 setup(
-    name='notifications-utils',
+    name="notifications-utils",
     version=version,
-    url='https://github.com/alphagov/notifications-utils',
-    license='MIT',
-    author='Government Digital Service',
-    description='Shared python code for GOV.UK Notify.',
+    url="https://github.com/alphagov/notifications-utils",
+    license="MIT",
+    author="Government Digital Service",
+    description="Shared python code for GOV.UK Notify.",
     long_description=__doc__,
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'bleach==3.3.0',
-        'cachetools==4.2.1',
-        'mistune==0.8.4',
-        'requests==2.25.1',
-        'python-json-logger==2.0.1',
-        'Flask>=0.12.2',
-        'orderedset==2.0.3',
-        'Jinja2==2.11.3',
-        'statsd==3.3.0',
-        'Flask-Redis==0.4.0',
-        'PyYAML==5.4.1',
-        'phonenumbers==8.12.21',
-        'pytz==2021.1',
-        'smartypants==2.0.1',
-        'pypdf2==1.26.0',
-
+        "bleach==3.3.0",
+        "cachetools==4.2.1",
+        "mistune==0.8.4",
+        "requests==2.25.1",
+        "python-json-logger==2.0.1",
+        "Flask>=0.12.2",
+        "orderedset==2.0.3",
+        "Jinja2==2.11.3",
+        "statsd==3.3.0",
+        "Flask-Redis==0.4.0",
+        "PyYAML==5.4.1",
+        "phonenumbers==8.12.21",
+        "pytz==2021.1",
+        "smartypants==2.0.1",
+        "pypdf2==1.26.0",
         # required by both api and admin
-        'awscli==1.19.58',
-        'boto3==1.17.58',
-    ]
+        "awscli==1.19.58",
+        "boto3==1.17.58",
+    ],
 )

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1,4 +1,5 @@
 import pytest
+from typing import Any, Dict
 from notifications_utils.field import Field, str2bool
 
 
@@ -74,7 +75,7 @@ def test_returns_a_string_without_placeholders(content):
         ("((warning??This is a conditional warning))", {"warning": False}, ""),
     ],
 )
-def test_replacement_of_placeholders(template_content, data, expected):
+def test_replacement_of_placeholders(template_content: str, data: Dict[str, Any], expected: str):
     assert str(Field(template_content, data)) == expected
 
 


### PR DESCRIPTION
# Summary | Résumé

This will make the mypy check part of CI. I had forgotten to do that before and was just running mypy manually.

I also added some type definitions and ran black on a file we had missed previously.