### PR TITLE
Fix template brackets bug

### DIFF
--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -55,7 +55,7 @@ HtmlSanitizers = Literal["strip", "escape", "passthrough", "strip_dvla_markup"]
 class Field:
     # this needs to be made conditional so it works in the (((colour))) -> (blue) case
     placeholder_pattern = re.compile(
-        r"\({2}([\s\S]+?)\){2}"  # opening ((, body of placeholder - potentially standard or conditional, closing ))
+        r"\({2}" r"([^()]+)" r"\){2}"  # opening ((, body of placeholder - potentially standard or conditional, closing ))
     )
     placeholder_tag = "<span class='placeholder'>(({}))</span>"
     conditional_placeholder_tag = "<span class='placeholder-conditional'>(({}??</span>{}))"
@@ -79,6 +79,8 @@ class Field:
 
         self.sanitizer = self.get_sanitizer(html)
         self.redact_missing_personalisation = redact_missing_personalisation
+        if '??' in self.content:
+            self.placeholder_pattern = re.compile(r"\({2}([\s\S]+?)\){2}")
 
     def __str__(self):
         if self.values:

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -79,7 +79,7 @@ class Field:
 
         self.sanitizer = self.get_sanitizer(html)
         self.redact_missing_personalisation = redact_missing_personalisation
-        if '??' in self.content:
+        if "??" in self.content:
             self.placeholder_pattern = re.compile(r"\({2}([\s\S]+?)\){2}")
 
     def __str__(self):

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -1,4 +1,3 @@
-from enum import Enum
 import re
 from typing import Any, Callable, Dict, List, Literal
 

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -54,6 +54,11 @@ HtmlSanitizers = Literal["strip", "escape", "passthrough", "strip_dvla_markup"]
 
 class Field:
     # this needs to be made conditional so it works in the (((colour))) -> (blue) case
+    # Deconstructed regular expression segments in order:
+    # * First segment: opening ((,
+    # * negative lookahead assertion to enforce consumption of late parenthesis and not early ones,
+    # * body of placeholder - potentially standard or conditional,
+    # * closing ))
     placeholder_pattern = re.compile(
         r"\({2}" r"([^()]+)" r"\){2}"  # opening ((, body of placeholder - potentially standard or conditional, closing ))
     )

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -59,9 +59,7 @@ class Field:
     # * negative lookahead assertion to enforce consumption of late parenthesis and not early ones,
     # * body of placeholder - potentially standard or conditional,
     # * closing ))
-    placeholder_pattern = re.compile(
-        r"\({2}" r"([^()]+)" r"\){2}"  # opening ((, body of placeholder - potentially standard or conditional, closing ))
-    )
+    placeholder_pattern = re.compile(r"\({2}" r"(?!\()" r"([\s\S]+?)" r"\){2}")
     placeholder_tag = "<span class='placeholder'>(({}))</span>"
     conditional_placeholder_tag = "<span class='placeholder-conditional'>(({}??</span>{}))"
     placeholder_tag_translated = "<span class='placeholder-no-brackets'>[{}]</span>"
@@ -84,8 +82,6 @@ class Field:
 
         self.sanitizer = self.get_sanitizer(html)
         self.redact_missing_personalisation = redact_missing_personalisation
-        if "??" in self.content:
-            self.placeholder_pattern = re.compile(r"\({2}([\s\S]+?)\){2}")
 
     def __str__(self):
         if self.values:

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -1,5 +1,6 @@
+from enum import Enum
 import re
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Literal
 
 from orderedset import OrderedSet
 from flask import Markup
@@ -49,6 +50,9 @@ class Placeholder:
         return "Placeholder({})".format(self.body)
 
 
+HtmlSanitizers = Literal["strip", "escape", "passthrough", "strip_dvla_markup"]
+
+
 class Field:
     placeholder_pattern = re.compile(
         r"\({2}" r"([^()]+)" r"\){2}"  # opening ((  # body of placeholder - potentially standard or conditional.  # closing ))
@@ -62,7 +66,7 @@ class Field:
         self,
         content: str,
         values: Dict[str, Any] = None,
-        html: str = "strip",
+        html: HtmlSanitizers = "strip",
         markdown_lists: bool = False,
         redact_missing_personalisation: bool = False,
         translated: bool = False,
@@ -85,14 +89,14 @@ class Field:
         return '{}("{}", {})'.format(self.__class__.__name__, self.content, self.values)  # TODO: more real
 
     @staticmethod
-    def get_sanitizer(method: str) -> Callable:
+    def get_sanitizer(html: HtmlSanitizers) -> Callable:
         sanitizers: Dict[str, Callable] = {
             "strip": strip_html,
             "escape": escape_html,
             "passthrough": str,
             "strip_dvla_markup": strip_dvla_markup,
         }
-        return sanitizers[method]
+        return sanitizers[html]
 
     @property
     def values(self):

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -54,8 +54,9 @@ HtmlSanitizers = Literal["strip", "escape", "passthrough", "strip_dvla_markup"]
 
 
 class Field:
+    # this needs to be made conditional so it works in the (((colour))) -> (blue) case
     placeholder_pattern = re.compile(
-        r"\({2}" r"([^()]+)" r"\){2}"  # opening ((  # body of placeholder - potentially standard or conditional.  # closing ))
+        r"\({2}([\s\S]+?)\){2}"  # opening ((, body of placeholder - potentially standard or conditional, closing ))
     )
     placeholder_tag = "<span class='placeholder'>(({}))</span>"
     conditional_placeholder_tag = "<span class='placeholder-conditional'>(({}??</span>{}))"

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -73,6 +73,7 @@ def test_returns_a_string_without_placeholders(content):
         ("((warning?warning))", {"warning?warning": "This is not a conditional"}, "This is not a conditional"),
         ("((warning??This is a conditional warning))", {"warning": True}, "This is a conditional warning"),
         ("((warning??This is a conditional warning))", {"warning": False}, ""),
+        ("((alert??Its up (yes)))", {"alert": True}, "Its up (yes)"),
     ],
 )
 def test_replacement_of_placeholders(template_content: str, data: Dict[str, Any], expected: str):
@@ -124,6 +125,8 @@ def test_optional_redacting_of_missing_values(template_content, data, expected):
         ("((warning?))", "<span class='placeholder'>((warning?))</span>"),
         ("((warning? This is not a conditional))", "<span class='placeholder'>((warning? This is not a conditional))</span>"),
         ("((warning?? This is a warning))", "<span class='placeholder-conditional'>((warning??</span> This is a warning))"),
+        ("((alert??Missing (i.e. Virtual Machine) ))",
+         "<span class='placeholder-conditional'>((alert??</span>Missing (i.e. Virtual Machine) ))"),
     ],
 )
 def test_formatting_of_placeholders(content, expected):

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -141,6 +141,10 @@ def test_optional_redacting_of_missing_values(template_content, data, expected):
             "((warning?)) and ((alert?? alert!))",
             "<span class='placeholder'>((warning?))</span> and <span class='placeholder-conditional'>((alert??</span> alert!))",
         ),
+        (
+            "(((warning))) and ((alert?? alert!))",
+            "(<span class='placeholder'>((warning))</span>) and <span class='placeholder-conditional'>((alert??</span> alert!))",
+        ),
     ],
 )
 def test_formatting_of_placeholders(content, expected):

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -74,14 +74,7 @@ def test_returns_a_string_without_placeholders(content):
         ("((warning??This is a conditional warning))", {"warning": True}, "This is a conditional warning"),
         ("((warning??This is a conditional warning))", {"warning": False}, ""),
         ("((alert??Its up (yes)))", {"alert": True}, "Its up (yes)"),
-        ("((ifvar?? ((ifyes))))", {"ifvar": True}, " ((ifyes))"),
-        ("((ifvar?? ((ifyes))))", {"ifvar": False}, ""),
-        ("((ifvar?? five (5) ))", {"ifvar": True}, " five (5) "),
-        ("((ifvar?? five (5) ))", {"ifvar": False}, ""),
-        ("((ifvar??five(5)))", {"ifvar": True}, "five(5)"),
-        ("((ifvar??five(5)))", {"ifvar": False}, ""),
-        ("((ifvar??(five)-(5)))", {"ifvar": True}, "(five)-(5)"),
-        ("((ifvar??(five)-(5)))", {"ifvar": False}, ""),
+        ("((ifvar?? (5) ))", {"ifvar": False}, ""),
     ],
 )
 def test_replacement_of_placeholders(template_content: str, data: Dict[str, Any], expected: str):

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -137,6 +137,10 @@ def test_optional_redacting_of_missing_values(template_content, data, expected):
             "((alert??Missing left parenthesis) ))",
             "<span class='placeholder-conditional'>((alert??</span>Missing left parenthesis) ))",
         ),
+        (
+            "((warning?)) and ((alert?? alert!))",
+            "<span class='placeholder'>((warning?))</span> and <span class='placeholder-conditional'>((alert??</span> alert!))",
+        ),
     ],
 )
 def test_formatting_of_placeholders(content, expected):

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -126,8 +126,16 @@ def test_optional_redacting_of_missing_values(template_content, data, expected):
         ("((warning? This is not a conditional))", "<span class='placeholder'>((warning? This is not a conditional))</span>"),
         ("((warning?? This is a warning))", "<span class='placeholder-conditional'>((warning??</span> This is a warning))"),
         (
-            "((alert??Missing (i.e. Virtual Machine) ))",
-            "<span class='placeholder-conditional'>((alert??</span>Missing (i.e. Virtual Machine) ))",
+            "((alert??With both (parenthesis) ))",
+            "<span class='placeholder-conditional'>((alert??</span>With both (parenthesis) ))",
+        ),
+        (
+            "((alert??Missing (right parenthesis ))",
+            "<span class='placeholder-conditional'>((alert??</span>Missing (right parenthesis ))",
+        ),
+        (
+            "((alert??Missing left parenthesis) ))",
+            "<span class='placeholder-conditional'>((alert??</span>Missing left parenthesis) ))",
         ),
     ],
 )

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -74,6 +74,14 @@ def test_returns_a_string_without_placeholders(content):
         ("((warning??This is a conditional warning))", {"warning": True}, "This is a conditional warning"),
         ("((warning??This is a conditional warning))", {"warning": False}, ""),
         ("((alert??Its up (yes)))", {"alert": True}, "Its up (yes)"),
+        ("((ifvar?? ((ifyes))))", {"ifvar": True}, " ((ifyes))"),
+        ("((ifvar?? ((ifyes))))", {"ifvar": False}, ""),
+        ("((ifvar?? five (5) ))", {"ifvar": True}, " five (5) "),
+        ("((ifvar?? five (5) ))", {"ifvar": False}, ""),
+        ("((ifvar??five(5)))", {"ifvar": True}, "five(5)"),
+        ("((ifvar??five(5)))", {"ifvar": False}, ""),
+        ("((ifvar??(five)-(5)))", {"ifvar": True}, "(five)-(5)"),
+        ("((ifvar??(five)-(5)))", {"ifvar": False}, ""),
     ],
 )
 def test_replacement_of_placeholders(template_content: str, data: Dict[str, Any], expected: str):

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -125,8 +125,10 @@ def test_optional_redacting_of_missing_values(template_content, data, expected):
         ("((warning?))", "<span class='placeholder'>((warning?))</span>"),
         ("((warning? This is not a conditional))", "<span class='placeholder'>((warning? This is not a conditional))</span>"),
         ("((warning?? This is a warning))", "<span class='placeholder-conditional'>((warning??</span> This is a warning))"),
-        ("((alert??Missing (i.e. Virtual Machine) ))",
-         "<span class='placeholder-conditional'>((alert??</span>Missing (i.e. Virtual Machine) ))"),
+        (
+            "((alert??Missing (i.e. Virtual Machine) ))",
+            "<span class='placeholder-conditional'>((alert??</span>Missing (i.e. Virtual Machine) ))",
+        ),
     ],
 )
 def test_formatting_of_placeholders(content, expected):


### PR DESCRIPTION
# Summary | Résumé

Trello: https://trello.com/c/ThRFxXRY/649-having-extra-parenthesis-in-a-condition-variable-make-the-latter-fail-in-templates

So far I have:
- improved a type definition (unrelated to the bug but I couldn't help myself)
- made a change to the regex that fixes the bug by putting it in a 'if' statement.
- Added tests