### PR TITLE
Display the brand text in alt attribute in email when defined

### DIFF
--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -91,7 +91,7 @@
                 border="0"
                 style="display: block; border: 0;"
                 height="{% if brand_text -%} 27 {%- else -%} 54 {%- endif %}"
-                alt="{% if brand_text %} {% else -%}{{ brand_name }}{%- endif %}"
+                alt="{% if brand_text %} {{ brand_text }} {% else -%}{{ brand_name }}{%- endif %}"
               />
             </td>
           {% endif %}
@@ -132,7 +132,7 @@
               <tr>
                 <td style="padding: 0 10px 0 {% if brand_colour %} 8px; border-left: solid 2px {{ brand_colour }}{% else %} 10px{% endif %}">
                   <img src="{{ brand_logo }}" style="display: block; border: 0" height="{% if brand_text -%} 27 {%- else -%} 108 {%- endif %}"
-                        alt="{% if brand_text %} {% else -%}{{ brand_name }}{%- endif %}" />
+                        alt="{% if brand_text %} {{ brand_text }} {% else -%}{{ brand_name }}{%- endif %}" />
                 </td>
                 <td width="100%" style="font-family: Helvetica, Arial, sans-serif; font-size: 18px; line-height: 23px;" valign="center">
                   {% if brand_text %}


### PR DESCRIPTION
# Summary | Résumé

We have a bug where the `alt` attribute is empty when the brand text is defined. Our expectation would be to have the `alt` attribute *always* defined for accessibility purpose. We elected to use the brand text for now, which is also used for the subtext of the logo when defined. Ideally, we might want to have a dedicated field for accessibility text in the admin to source it through the generated branding in emails.

# Test instructions | Instructions pour tester la modification

Send an email with the brand text defined. The `alt` attribute should be the same as the brand text, whereas previous to these changes, it was blank with an empty space.

# Unresolved questions / Out of scope | Questions non résolues ou hors sujet

* Do we want to have a dedicated accessibility brand text to have complete control of the `alt` attribute? At the moment, the brand subtitle text and `alt` attribute will be the same but that would not be following proper accessibility standard.

# Reviewer checklist | Liste de vérification du réviseur

This is a suggested checklist of questions reviewers might ask during their
review | Voici une suggestion de liste de vérification comprenant des questions
que les réviseurs pourraient poser pendant leur examen :


- [ ] Does this meet a user need? | Est-ce que ça répond à un besoin utilisateur?
- [ ] Is it accessible? | Est-ce que c’est accessible?
- [ ] Is it translated between both offical languages? | Est-ce dans les deux
      langues officielles?
- [ ] Is the code maintainable? | Est-ce que le code peut être maintenu?
- [ ] Have you tested it? | L’avez-vous testé?
- [ ] Are there automated tests? | Y a-t-il des tests automatisés?
- [ ] Does this cause automated test coverage to drop? | Est-ce que ça entraîne
      une baisse de la quantité de code couvert par les tests automatisés?
- [ ] Does this break existing functionality? | Est-ce que ça brise une
      fonctionnalité existante?
- [ ] Should this be split into smaller PRs to decrease change risk? | Est-ce
      que ça devrait être divisé en de plus petites demandes de tirage (« pull
      requests ») afin de réduire le risque lié aux modifications?
- [ ] Does this change the privacy policy? | Est-ce que ça entraîne une
      modification de la politique de confidentialité?
- [ ] Does this introduce any security concerns? | Est-ce que ça introduit des
      préoccupations liées à la sécurité?
- [ ] Does this significantly alter performance? | Est-ce que ça modifie de
      façon importante la performance?
- [ ] What is the risk level of using added dependencies? | Quel est le degré de
      risque d’utiliser des dépendances ajoutées?
- [ ] Should any documentation be updated as a result of this? (i.e. README
      setup, etc.) | Faudra-t-il mettre à jour la documentation à la suite de ce
      changement (fichier README, etc.)?
