### PR TITLE
feat: get class attribute name/values 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,30 @@
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.9
+
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install \
+        curl \
+        emacs \
+        exa \
+        fd-find \
+        git \ 
+        iproute2 \
+        less \ 
+        libsodium-dev \
+        lsb-release \ 
+        man-db \
+        manpages \
+        net-tools \
+        openssh-client \ 
+        procps \ 
+        sudo \
+        tldr \
+        unzip \
+        vim \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install --upgrade pip
+
+COPY scripts/bootstrap.sh /usr/local/bin/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+	"name": "notification-utils",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": ".."
+	},
+
+	"remoteEnv": {
+		"PATH": "/home/vscode/.local/bin:${containerEnv:PATH}" // give our installed Python modules precedence
+	},
+
+	"containerEnv": {
+		"SHELL": "/bin/zsh"
+	},
+
+	"settings": { 
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.linting.pylintPath": "/usr/local/bin/pylint",
+		"python.pythonPath": "/usr/local/bin/python",
+	},
+
+	"extensions": [
+		"donjayamanne.python-extension-pack",
+		"ms-python.vscode-pylance",
+		"eamodio.gitlens",
+		"GitHub.copilot",
+	],
+
+	"postCreateCommand": "bootstrap.sh",
+}

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -7,6 +7,7 @@ from flask import request, g
 from flask.ctx import has_request_context
 from pythonjsonlogger.jsonlogger import JsonFormatter as BaseJSONFormatter
 from time import monotonic
+from typing import Any
 
 import logging
 import logging.handlers
@@ -140,6 +141,19 @@ def configure_handler(handler, app, formatter):
     handler.addFilter(RequestIdFilter())
 
     return handler
+
+
+def get_class_attrs(cls, sensitive_attrs: list[str]) -> dict[str, Any]:
+    """
+    Returns a dict of Class attribute key/values.  Any attribute names in the
+    sensitive_attrs list will be masked.
+    """
+    attrs = {}
+    for attr in dir(cls):
+        attr_value = "***" if attr in sensitive_attrs else getattr(cls, attr)
+        if not attr.startswith("__") and not callable(attr_value):
+            attrs[attr] = attr_value
+    return attrs
 
 
 class AppNameFilter(logging.Filter):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = "46.4.0"
+__version__ = "46.5.0"
 # GDS version '34.0.1'

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = "46.3.0"
+__version__ = "46.4.0"
 # GDS version '34.0.1'

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -158,3 +158,33 @@ def test_logging_records_statsd_stats_without_time(app_with_statsd, service_id):
         else:
             assert statsd.incr.call_args_list == [call("GET.homepage.200")]
             statsd.timing.assert_not_called()
+
+
+def test_get_class_attrs():
+    class Config:
+        some_dict = {
+            "FOO": "bar",
+            "BAM": "baz",
+        }
+        env = "prod"
+
+        def some_function(self):
+            return True
+
+    assert logging.get_class_attrs(Config, []) == {
+        "some_dict": {
+            "FOO": "bar",
+            "BAM": "baz",
+        },
+        "env": "prod",
+    }
+
+    an_instance = Config()
+    an_instance.some_dict = {"BAR": "bloop"}
+
+    assert logging.get_class_attrs(an_instance, ["env"]) == {
+        "some_dict": {
+            "BAR": "bloop",
+        },
+        "env": "***",
+    }


### PR DESCRIPTION
# Summary
Add a `get_class_attrs` logging method that can be used to get a
dict of a Class attribute name/value pairs.  This will replace 
the current [Config.get_config class method](https://github.com/cds-snc/notification-api/blob/e39d2ac3b4dc1a758dc2093cbdff142a07ef2c26/app/config.py#L482-L490).

This will be used to dump the Config class values when Notify
services start to validate they are configured as expected.

# Note
This PR also adds a VS Code devcontainer for local development.

# Related
* cds-snc/notification-planning#522