### PR TITLE
fix: GitHub waffles action by pinning markupsafe

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,2 +1,3 @@
 docopt==0.6.2
 Flask==1.1.4
+markupsafe==2.0.1


### PR DESCRIPTION
# Summary
Pin the markupsafe package since the `soft_unicode` has been removed
which was causing all CI action runs to fail with an import error:

```python
ImportError: cannot import name 'soft_unicode' from 'markupsafe'
```