### PR TITLE
feat: generate Software Bill of Materials

### DIFF
--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -1,0 +1,29 @@
+name: Generate SBOM
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - requirements.txt
+      - .github/workflows/generate-sbom.yml
+  push:
+    branches:
+      - main
+    paths:
+      - requirements.txt
+      - .github/workflows/generate-sbom.yml
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Generate app SBOM
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@d39a08b2145375940f52c0b4b8c58a8cf3603bdb
+        with:
+          dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
+          project_name: notification-utils/package
+          project_type: python        

--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Generate app SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@d39a08b2145375940f52c0b4b8c58a8cf3603bdb
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@b09c1aefae9876dd2a23888c50b2daaa137ba01d # pin@v1
         with:
           dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           project_name: notification-utils/package

--- a/.github/workflows/generate-sbom.yml
+++ b/.github/workflows/generate-sbom.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Generate app SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@b09c1aefae9876dd2a23888c50b2daaa137ba01d # pin@v1
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@14ab23f07437d642594c56003db1f4bd34e54bbb # renovate: tag=v1
         with:
           dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
           project_name: notification-utils/package


### PR DESCRIPTION
# Summary
Add GitHub workflows to generate SBOMs and upload them
to Dependency-Track. This will allow us to have a view of all
the dependencies used by the org and their potential
vulnerabilities.

# Related
* cds-snc/platform-sre-security-support#94