### PR TITLE
Update dependencies (part of werkzeug upgrade)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
 python_version = 3.9
 check_untyped_defs = True
+exclude = venv|build
 
 [mypy-orderedset.*]
 ignore_missing_imports = True

--- a/notifications_utils/statsd_decorators.py
+++ b/notifications_utils/statsd_decorators.py
@@ -13,8 +13,10 @@ def statsd(namespace):
             try:
                 res = func(*args, **kwargs)
                 elapsed_time = monotonic() - start_time
-                current_app.statsd_client.incr("{namespace}.{func}".format(namespace=namespace, func=func.__name__))
-                current_app.statsd_client.timing(
+                current_app.statsd_client.incr(  # type: ignore
+                    "{namespace}.{func}".format(namespace=namespace, func=func.__name__)
+                )
+                current_app.statsd_client.timing(  # type: ignore
                     "{namespace}.{func}".format(namespace=namespace, func=func.__name__), elapsed_time
                 )
 
@@ -68,7 +70,7 @@ def statsd_catch(namespace: str, counter_name: str, exception: Type[Exception]):
             try:
                 return func(*args, **kwargs)
             except exception as e:
-                current_app.statsd_client.incr(f"{namespace}.{counter_name}")
+                current_app.statsd_client.incr(f"{namespace}.{counter_name}")  # type: ignore
                 raise e
 
         wrapper.__wrapped__.__name__ = func.__name__  # type: ignore

--- a/notifications_utils/statsd_decorators.py
+++ b/notifications_utils/statsd_decorators.py
@@ -13,10 +13,8 @@ def statsd(namespace):
             try:
                 res = func(*args, **kwargs)
                 elapsed_time = monotonic() - start_time
-                current_app.statsd_client.incr(  # type: ignore
-                    "{namespace}.{func}".format(namespace=namespace, func=func.__name__)
-                )
-                current_app.statsd_client.timing(  # type: ignore
+                current_app.statsd_client.incr("{namespace}.{func}".format(namespace=namespace, func=func.__name__))
+                current_app.statsd_client.timing(
                     "{namespace}.{func}".format(namespace=namespace, func=func.__name__), elapsed_time
                 )
 
@@ -70,7 +68,7 @@ def statsd_catch(namespace: str, counter_name: str, exception: Type[Exception]):
             try:
                 return func(*args, **kwargs)
             except exception as e:
-                current_app.statsd_client.incr(f"{namespace}.{counter_name}")  # type: ignore
+                current_app.statsd_client.incr(f"{namespace}.{counter_name}")
                 raise e
 
         wrapper.__wrapped__.__name__ = func.__name__  # type: ignore

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = "46.5.0"
+__version__ = "47.0.0"
 # GDS version '34.0.1'

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,10 +1,10 @@
 -r requirements.txt
-pytest==6.2.3
-pytest-mock==3.5.1
+pytest==7.1.2
+pytest-mock==3.7.0
 pytest-cov==2.11.1
-pytest-xdist==2.2.1
+pytest-xdist==2.5.0
+freezegun==1.2.1
 requests-mock==1.9.3
-freezegun==1.1.0
 flake8==3.9.1
 flake8-print==4.0.0
 mypy==0.812


### PR DESCRIPTION
# Summary | Résumé
- Update test deps to get the utils library in line with admin and api as part of the werkzeug upgrade.
- Configure mypy to skip directories it shouldn't look in
- Ignore type errors related to statsd