### PR TITLE
support base64_uuid in urls

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,3 +1,4 @@
 docopt==0.6.2
-Flask==1.1.4
+Flask==2.0.3
 markupsafe==2.0.1
+git+https://github.com/cds-snc/notifier-utils.git@48.0.0#egg=notifications-utils

--- a/.github/actions/waffles/waffles.py
+++ b/.github/actions/waffles/waffles.py
@@ -40,8 +40,7 @@ from typing import Any, List, NewType
 from urllib import request
 from urllib.error import URLError
 
-sys.path.append("../../..")
-from notifications_utils.base64_uuid import uuid_to_base64  # noqa: E402 module level import not at top of file
+from notifications_utils.base64_uuid import uuid_to_base64
 
 ModuleName = NewType("ModuleName", str)
 ModuleProp = NewType("ModuleProp", str)

--- a/.github/actions/waffles/waffles.py
+++ b/.github/actions/waffles/waffles.py
@@ -40,6 +40,10 @@ from typing import Any, List, NewType
 from urllib import request
 from urllib.error import URLError
 
+import sys
+
+sys.path.append("../../..")
+from notifications_utils.base64_uuid import uuid_to_base64
 
 ModuleName = NewType("ModuleName", str)
 ModuleProp = NewType("ModuleProp", str)
@@ -253,6 +257,7 @@ def _transform_endpoint(endpoint: URL) -> URL:
         URL: The transformed URL.
     """
     endpoint = URL(re.sub(r"<uuid:[^>]*>", str(_create_uuid()), endpoint))
+    endpoint = URL(re.sub(r"<base64_uuid:[^>]*>", str(uuid_to_base64(_create_uuid())), endpoint))
     endpoint = URL(endpoint.replace("<path:filename>", "filename.txt"))
     return endpoint
 

--- a/.github/actions/waffles/waffles.py
+++ b/.github/actions/waffles/waffles.py
@@ -40,10 +40,8 @@ from typing import Any, List, NewType
 from urllib import request
 from urllib.error import URLError
 
-import sys
-
 sys.path.append("../../..")
-from notifications_utils.base64_uuid import uuid_to_base64
+from notifications_utils.base64_uuid import uuid_to_base64  # noqa: E402 module level import not at top of file
 
 ModuleName = NewType("ModuleName", str)
 ModuleProp = NewType("ModuleProp", str)


### PR DESCRIPTION
# Summary | Résumé

This is part of [archiving document-download-frontend](https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/cds-snc/notification-planning/240).

[Adding a new endpoint to document-download-api](https://github.com/cds-snc/notification-document-download-api/pull/65) also requires:
1. [Add this endpoint to the WAF allowList.](https://github.com/cds-snc/notification-terraform/pull/492)
2. Change the waffles test to support `base64_uuid` (this PR).


# Test instructions | Instructions pour tester la modification

1. clone the [document-download-api](https://github.com/cds-snc/notification-document-download-api) and switch to [this branch]( https://github.com/cds-snc/notification-document-download-api/pull/65)
2. `pip install` the waffles requirements in a virtualenv
3. Run something similar (with your file locations) to
```
python waffles.py iron --base-url=https://api.document.staging.notification.cdssandbox.xyz --app-loc ~/Git/notification-document-download-api --app-lib ~/.virtualenvs/notification-document-download-api/lib/python3.9/site-packages --flask-mod application --flask-prop application
```
4. You should see something like
```
Hitting endpoint 'https://api.document.staging.notification.cdssandbox.xyz/_status'... OK.
Hitting endpoint 'https://api.document.staging.notification.cdssandbox.xyz/d/e43YBLFRQ4abXOOwBZo0wQ/e43YBLFRQ4abXOOwBZo0wQ'... OK.
Hitting endpoint 'https://api.document.staging.notification.cdssandbox.xyz/services/87406a0c-fe0d-4e29-b895-ce838bc18a7c/documents'... OK.
Hitting endpoint 'https://api.document.staging.notification.cdssandbox.xyz/services/69d8ad5b-84c1-4af9-9ea1-b3aeb20af80f/documents/69d8ad5b-84c1-4af9-9ea1-b3aeb20af80f'... OK.
```
Note that this PR adds the base64'd UUID `e43YBLFRQ4abXOOwBZo0wQ` to the second endpoint.
