### PR TITLE
placeholder meta

### DIFF
--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -166,6 +166,14 @@ class Field:
         return OrderedSet(Placeholder(body).name for body in re.findall(self.placeholder_pattern, self.content))
 
     @property
+    def placeholders_meta(self):
+        meta = {
+            Placeholder(body).name: {"is_conditional": Placeholder(body).is_conditional()}
+            for body in re.findall(self.placeholder_pattern, self.content)
+        }
+        return meta
+
+    @property
     def replaced(self):
         return re.sub(self.placeholder_pattern, self.replace_match, self.sanitizer(self.content))
 

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -136,6 +136,10 @@ class Template:
         return Field(self.content).placeholders
 
     @property
+    def placeholders_meta(self):
+        return Field(self.content).placeholders_meta
+
+    @property
     def missing_data(self):
         return list(placeholder for placeholder in self.placeholders if self.values.get(placeholder) is None)
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = "48.0.0"
+__version__ = "48.1.0"
 # GDS version '34.0.1'


### PR DESCRIPTION
# Summary | Résumé

For this a11y task: https://github.com/cds-snc/notification-planning/issues/580

This add some meta information about placeholders when working with templates. 

Which means we can know whether a field should behave like a boolean, or like a string (They're still all strings though). This only enhances the UX and a11y, should not change any functionality. 