### PR TITLE
Fix/repeated lang tags

### DIFF
--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -610,16 +610,16 @@ def add_language_divs(_content: str) -> str:
     because the mistune parser has already run and put our [[lang]] tags inside
     paragraphs.
     """
-    select_anything = r"([\s\S]*)"
+    select_anything = r"([\s\S]*?)"
     fr_regex = re.compile(
-        f"{EMAIL_P_OPEN_TAG}{FR_OPEN}{EMAIL_P_CLOSE_TAG}{select_anything}{EMAIL_P_OPEN_TAG}{FR_CLOSE}{EMAIL_P_CLOSE_TAG}"
+        f"({EMAIL_P_OPEN_TAG})?{FR_OPEN}({EMAIL_P_CLOSE_TAG})?{select_anything}({EMAIL_P_OPEN_TAG})?{FR_CLOSE}({EMAIL_P_CLOSE_TAG})?"  # noqa
     )  # matches <p ...>[[fr]]</p>anything<p ...>[[/fr]]</p>
-    content = fr_regex.sub(r'<div lang="fr-ca">\1</div>', _content)  # \1 returns the "anything" content above
+    content = fr_regex.sub(r'<div lang="fr-ca">\3</div>', _content)  # \1 returns the "anything" content above
 
     en_regex = re.compile(
-        f"{EMAIL_P_OPEN_TAG}{EN_OPEN}{EMAIL_P_CLOSE_TAG}{select_anything}{EMAIL_P_OPEN_TAG}{EN_CLOSE}{EMAIL_P_CLOSE_TAG}"
+        f"({EMAIL_P_OPEN_TAG})?{EN_OPEN}({EMAIL_P_CLOSE_TAG})?{select_anything}({EMAIL_P_OPEN_TAG})?{EN_CLOSE}({EMAIL_P_CLOSE_TAG})?"  # noqa
     )  # matches <p ...>[[en]]</p>anything<p ...>[[/en]]</p>
-    content = en_regex.sub(r'<div lang="en-ca">\1</div>', content)  # \1 returns the "anything" content above
+    content = en_regex.sub(r'<div lang="en-ca">\3</div>', content)  # \1 returns the "anything" content above
     return content
 
 

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -614,12 +614,12 @@ def add_language_divs(_content: str) -> str:
     fr_regex = re.compile(
         f"({EMAIL_P_OPEN_TAG})?{FR_OPEN}({EMAIL_P_CLOSE_TAG})?{select_anything}({EMAIL_P_OPEN_TAG})?{FR_CLOSE}({EMAIL_P_CLOSE_TAG})?"  # noqa
     )  # matches <p ...>[[fr]]</p>anything<p ...>[[/fr]]</p>
-    content = fr_regex.sub(r'<div lang="fr-ca">\3</div>', _content)  # \1 returns the "anything" content above
+    content = fr_regex.sub(r'<div lang="fr-ca">\3</div>', _content)  # \3 returns the "anything" content above (3rd group)
 
     en_regex = re.compile(
         f"({EMAIL_P_OPEN_TAG})?{EN_OPEN}({EMAIL_P_CLOSE_TAG})?{select_anything}({EMAIL_P_OPEN_TAG})?{EN_CLOSE}({EMAIL_P_CLOSE_TAG})?"  # noqa
     )  # matches <p ...>[[en]]</p>anything<p ...>[[/en]]</p>
-    content = en_regex.sub(r'<div lang="en-ca">\3</div>', content)  # \1 returns the "anything" content above
+    content = en_regex.sub(r'<div lang="en-ca">\3</div>', content)  # \3 returns the "anything" content above (3rd group)
     return content
 
 

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -748,7 +748,6 @@ def get_html_email_body(template_content, template_values, redact_missing_person
         )
         .then(unlink_govuk_escaped)
         .then(strip_unsupported_characters)
-        # .then(add_newlines_around_lang_tags)
         .then(add_trailing_newline)
         .then(notify_email_markdown)
         .then(add_language_divs)

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -20,7 +20,6 @@ from notifications_utils.formatters import (
     add_ircc_gc_seal,
     add_language_divs,
     add_prefix,
-    add_newlines_around_lang_tags,
     autolink_sms,
     notify_email_markdown,
     notify_email_preheader_markdown,
@@ -749,7 +748,7 @@ def get_html_email_body(template_content, template_values, redact_missing_person
         )
         .then(unlink_govuk_escaped)
         .then(strip_unsupported_characters)
-        .then(add_newlines_around_lang_tags)
+        # .then(add_newlines_around_lang_tags)
         .then(add_trailing_newline)
         .then(notify_email_markdown)
         .then(add_language_divs)

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = "48.1.0"
+__version__ = "48.1.1"
 # GDS version '34.0.1'

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = "48.1.1"
+__version__ = "48.2.0"
 # GDS version '34.0.1'

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -14,13 +14,10 @@ def test_lang_tags_in_templates():
     "bad_content",
     [
         "[[en]\nEN text\n[[/en]]",  # missing bracket
-        # "[[en]]EN text\n[[/en]]",  # missing \n
-        # "[[en]]\nEN text[[/en]]",  # missing \n
         "[[EN]]\nEN text\n[[/EN]]",  # tags not lowercase
         "[[en]]\nEN text\n",  # tag missing
         "EN text\n[[/en]]",  # tag missing
         "((en))\nEN text\n((/en))",  # wrong brackets
-        # "[[en]]EN text[[/en]]",  # tags not on their own line
     ],
 )
 def test_lang_tags_in_templates_bad_content(bad_content: str):

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -14,13 +14,13 @@ def test_lang_tags_in_templates():
     "bad_content",
     [
         "[[en]\nEN text\n[[/en]]",  # missing bracket
-        "[[en]]EN text\n[[/en]]",  # missing \n
-        "[[en]]\nEN text[[/en]]",  # missing \n
+        # "[[en]]EN text\n[[/en]]",  # missing \n
+        # "[[en]]\nEN text[[/en]]",  # missing \n
         "[[EN]]\nEN text\n[[/EN]]",  # tags not lowercase
         "[[en]]\nEN text\n",  # tag missing
         "EN text\n[[/en]]",  # tag missing
         "((en))\nEN text\n((/en))",  # wrong brackets
-        "[[en]]EN text[[/en]]",  # tags not on their own line
+        # "[[en]]EN text[[/en]]",  # tags not on their own line
     ],
 )
 def test_lang_tags_in_templates_bad_content(bad_content: str):


### PR DESCRIPTION
# Summary | Résumé
This PR updates the template processing logic to:
- support multiple language tags 
- be a little more flexible in that it doesn't care if there are explicit newlines or whether or not mistune has peppered the markup with `<p>` tags and inline styles. (this will hopefully help us be resilient whenever we decide to update mistune)
- support nested language tags, provided that the nested tag is different than the parent one

## Examples 
### Multiple language tags 
```
[[fr]]
Le français suis l'anglais
[[/fr]]

[[en]]
hi
[[/en]]

[[fr]]
Bonjour
[[/fr]]
```

### Newline flexibility
```
[[fr]]Le français suis l'anglais[[/fr]]
[[en]]hi[[/en]]
[[fr]]Bonjour[[/fr]]
```

### Nested tags
This will be supported:
```
[[en]] Hello! [[fr]] Bonjour [[/fr]] [[/en]]
```

And this will not be:
```
[[en]] Hello! [[en]] Still english [[/en]] [[/en]]
```