### PR TITLE
add support for GCA extra routes in waffles

### DIFF
--- a/.github/actions/waffles/waffles.py
+++ b/.github/actions/waffles/waffles.py
@@ -95,7 +95,13 @@ def _display_flask_endpoints(flask_app: Flask) -> None:
         methods = ",".join(rule.methods)
         line = urllib.parse.unquote("{:50s} {:20s} {}".format(rule.endpoint, methods, rule))
         output.append(line)
-    for line in sorted(output):
+
+    output = sorted(output)
+    for extra_endpoint in flask_app.config.get("EXTRA_ROUTES", []):
+        line = urllib.parse.unquote("EXTRA {:44s} {:20s} {}".format(extra_endpoint, "GET", extra_endpoint))
+        output.append(line)
+
+    for line in output:
         print(line)
 
 
@@ -112,6 +118,12 @@ def _get_flask_endpoints(flask_app: Flask) -> List[URL]:
     for rule in flask_app.url_map.iter_rules():
         endpoint = URL(rule.rule)
         endpoints.append(endpoint)
+
+    for extra_endpoint in flask_app.config.get("EXTRA_ROUTES", []):
+        endpoint = URL(extra_endpoint)
+        endpoints.append(endpoint)
+
+    return endpoints
     return sorted(endpoints)
 
 

--- a/.github/actions/waffles/waffles.py
+++ b/.github/actions/waffles/waffles.py
@@ -123,7 +123,6 @@ def _get_flask_endpoints(flask_app: Flask) -> List[URL]:
         endpoint = URL(extra_endpoint)
         endpoints.append(endpoint)
 
-    return endpoints
     return sorted(endpoints)
 
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = "48.1.0"
+__version__ = "48.1.1"
 # GDS version '34.0.1'


### PR DESCRIPTION
# Summary | Résumé

add support for extra routes contained in an app's config variable `EXTRA_ROUTES`

This allows us to test admin's GCA routes.

# Test instructions | Instructions pour tester la modification

run together with https://github.com/cds-snc/notification-admin/pull/1325 to see the GCA routes listed  / tested

```
python waffles.py iron --base-url=https://staging.notification.cdssandbox.xyz --app-loc ~/Git/notification-admin --app-lib ~/.virtualenvs/notification-admin/lib/python3.9/site-packages --flask-mod application --flask-prop application
```

```
...
Hitting endpoint 'https://staging.notification.cdssandbox.xyz/users/<user_id>'... OK.
Hitting endpoint 'https://staging.notification.cdssandbox.xyz/<path:path>'... OK.
Hitting endpoint 'https://staging.notification.cdssandbox.xyz/home'... OK.
Hitting endpoint 'https://staging.notification.cdssandbox.xyz/accueil'... OK.
Hitting endpoint 'https://staging.notification.cdssandbox.xyz/why-gc-notify'... OK.
Hitting endpoint 'https://staging.notification.cdssandbox.xyz/pourquoi-gc-notification'... OK.
Hitting endpoint 'https://staging.notification.cdssandbox.xyz/features'... OK.
Hitting endpoint 'https://staging.notification.cdssandbox.xyz/fonctionnalites'... OK.
Hitting endpoint 'https://staging.notification.cdssandbox.xyz/guidance'... OK.
...
```
