### PR TITLE
Add sms count to redis

### DIFF
--- a/notifications_utils/clients/redis/__init__.py
+++ b/notifications_utils/clients/redis/__init__.py
@@ -25,13 +25,13 @@ def rate_limit_cache_key(service_id, api_key_type):
     return "{}-{}".format(str(service_id), api_key_type)
 
 
-def sms_daily_limit_cache_key(service_id):
+def sms_daily_count_cache_key(service_id):
     return "sms-{}-{}-{}".format(str(service_id), datetime.utcnow().strftime("%Y-%m-%d"), "count")
 
 
 def near_sms_daily_limit_cache_key(service_id):
-    return f"nearing-{daily_limit_cache_key(service_id)}"
+    return f"nearing-daily-limit-{sms_daily_count_cache_key(service_id)}"
 
 
 def over_sms_daily_limit_cache_key(service_id):
-    return f"over-{daily_limit_cache_key(service_id)}"
+    return f"over-daily-limit-{sms_daily_count_cache_key(service_id)}"

--- a/notifications_utils/clients/redis/__init__.py
+++ b/notifications_utils/clients/redis/__init__.py
@@ -23,3 +23,15 @@ def over_daily_limit_cache_key(service_id):
 
 def rate_limit_cache_key(service_id, api_key_type):
     return "{}-{}".format(str(service_id), api_key_type)
+
+
+def sms_daily_limit_cache_key(service_id):
+    return "sms-{}-{}-{}".format(str(service_id), datetime.utcnow().strftime("%Y-%m-%d"), "count")
+
+
+def near_sms_daily_limit_cache_key(service_id):
+    return f"nearing-{daily_limit_cache_key(service_id)}"
+
+
+def over_sms_daily_limit_cache_key(service_id):
+    return f"over-{daily_limit_cache_key(service_id)}"

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -147,6 +147,14 @@ class RedisClient:
             except Exception as e:
                 self.__handle_exception(e, raise_exception, "incr", key)
 
+    def incrby(self, key, by, raise_exception=False):
+        key = prepare_value(key)
+        if self.active:
+            try:
+                return self.redis_store.incrby(key, by)
+            except Exception as e:
+                self.__handle_exception(e, raise_exception, "incrby", key)
+
     def get(self, key, raise_exception=False):
         key = prepare_value(key)
         if self.active:

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,3 +1,2 @@
-
 __version__ = "48.2.0"
 # GDS version '34.0.1'

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = "48.1.0"
+__version__ = "48.2.0"
 # GDS version '34.0.1'

--- a/tests/test_redis_client.py
+++ b/tests/test_redis_client.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 
 from notifications_utils.clients.redis import (
     daily_limit_cache_key,
-    sms_daily_limit_cache_key,
+    sms_daily_count_cache_key,
     rate_limit_cache_key,
 )
 from notifications_utils.clients.redis.redis_client import RedisClient, prepare_value
@@ -131,9 +131,9 @@ def test_should_build_cache_key_service_and_action(sample_service):
         assert daily_limit_cache_key(sample_service.id) == "{}-2016-01-01-count".format(sample_service.id)
 
 
-def test_should_build_cache_key_service_and_action(sample_service):
+def test_should_build_sms_cache_key_service_and_action(sample_service):
     with freeze_time("2016-01-01 12:00:00.000000"):
-        assert sms_daily_limit_cache_key(sample_service.id) == "sms-{}-2016-01-01-count".format(sample_service.id)
+        assert sms_daily_count_cache_key(sample_service.id) == "sms-{}-2016-01-01-count".format(sample_service.id)
 
 
 def test_should_build_rate_limit_cache_key(sample_service):

--- a/tests/test_redis_client.py
+++ b/tests/test_redis_client.py
@@ -53,6 +53,7 @@ def test_should_not_raise_exception_if_raise_set_to_false(app, caplog, mocker):
     assert redis_client.get("get_key") is None
     assert redis_client.set("set_key", "set_value") is None
     assert redis_client.incr("incr_key") is None
+    assert redis_client.incrby("incrby_key", by=1) is None
     assert redis_client.exceeded_rate_limit("rate_limit_key", 100, 100) is False
     assert redis_client.expire("expire_key", 100) is None
     assert redis_client.delete("delete_key") is None
@@ -61,6 +62,7 @@ def test_should_not_raise_exception_if_raise_set_to_false(app, caplog, mocker):
         call.exception("Redis error performing get on get_key"),
         call.exception("Redis error performing set on set_key"),
         call.exception("Redis error performing incr on incr_key"),
+        call.exception("Redis error performing incrby on incrby_key"),
         call.exception("Redis error performing rate-limit-pipeline on rate_limit_key"),
         call.exception("Redis error performing expire on expire_key"),
         call.exception("Redis error performing delete on delete_key"),
@@ -74,7 +76,8 @@ def test_should_raise_exception_if_raise_set_to_true(app):
     redis_client.init_app(app)
     redis_client.redis_store.get = Mock(side_effect=Exception("get failed"))
     redis_client.redis_store.set = Mock(side_effect=Exception("set failed"))
-    redis_client.redis_store.incr = Mock(side_effect=Exception("inc failed"))
+    redis_client.redis_store.incr = Mock(side_effect=Exception("incr failed"))
+    redis_client.redis_store.incrby = Mock(side_effect=Exception("incrby failed"))
     redis_client.redis_store.pipeline = Mock(side_effect=Exception("pipeline failed"))
     redis_client.redis_store.expire = Mock(side_effect=Exception("expire failed"))
     redis_client.redis_store.delete = Mock(side_effect=Exception("delete failed"))
@@ -86,7 +89,10 @@ def test_should_raise_exception_if_raise_set_to_true(app):
     assert str(e.value) == "set failed"
     with pytest.raises(Exception) as e:
         redis_client.incr("test", raise_exception=True)
-    assert str(e.value) == "inc failed"
+    assert str(e.value) == "incr failed"
+    with pytest.raises(Exception) as e:
+        redis_client.incrby("test", by=1, raise_exception=True)
+    assert str(e.value) == "incrby failed"
     with pytest.raises(Exception) as e:
         redis_client.exceeded_rate_limit("test", 100, 200, raise_exception=True)
     assert str(e.value) == "pipeline failed"

--- a/tests/test_redis_client.py
+++ b/tests/test_redis_client.py
@@ -6,6 +6,7 @@ from freezegun import freeze_time
 
 from notifications_utils.clients.redis import (
     daily_limit_cache_key,
+    sms_daily_limit_cache_key,
     rate_limit_cache_key,
 )
 from notifications_utils.clients.redis.redis_client import RedisClient, prepare_value
@@ -130,7 +131,12 @@ def test_should_build_cache_key_service_and_action(sample_service):
         assert daily_limit_cache_key(sample_service.id) == "{}-2016-01-01-count".format(sample_service.id)
 
 
-def test_should_build_daily_limit_cache_key(sample_service):
+def test_should_build_cache_key_service_and_action(sample_service):
+    with freeze_time("2016-01-01 12:00:00.000000"):
+        assert sms_daily_limit_cache_key(sample_service.id) == "sms-{}-2016-01-01-count".format(sample_service.id)
+
+
+def test_should_build_rate_limit_cache_key(sample_service):
     assert rate_limit_cache_key(sample_service.id, "TEST") == "{}-TEST".format(sample_service.id)
 
 


### PR DESCRIPTION
# Summary | Résumé

Add redis cache keys for sms daily counts.

We store the daily notify counts for a service in redis (rather than doing a database query every time!) - here I add in code to put sms counts in redis too.

Note that it's api that actually sets and uses the values, but utils manages the naming 🤷 

Also added an "increment by" function since the sms counts will go up by more than one (for sms with more than one message part)
