### PR TITLE
Fix is_conditional bug

### DIFF
--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -168,12 +168,21 @@ class Field:
     @property
     def placeholders_meta(self):
         meta = {}
+
+        # This loop iterates over each instance in the template where a variable is used.
+        # The same variable will be hit multiple times if it appears more than
+        # once.
         for body in re.findall(self.placeholder_pattern, self.content):
             if Placeholder(body).name not in meta:
                 # never let a False overwrite a True
                 meta[Placeholder(body).name] = {"is_conditional": False}
+
+            # If the variable appears in a conditional statement in the template,
+            # we consider it a conditional variable and encourage the user to set it to a
+            # boolean value
             if Placeholder(body).is_conditional():
                 meta[Placeholder(body).name] = {"is_conditional": True}
+
         return meta
 
     @property

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -167,10 +167,13 @@ class Field:
 
     @property
     def placeholders_meta(self):
-        meta = {
-            Placeholder(body).name: {"is_conditional": Placeholder(body).is_conditional()}
-            for body in re.findall(self.placeholder_pattern, self.content)
-        }
+        meta = {}
+        for body in re.findall(self.placeholder_pattern, self.content):
+            if Placeholder(body).name not in meta:
+                # never let a False overwrite a True
+                meta[Placeholder(body).name] = {"is_conditional": False}
+            if Placeholder(body).is_conditional():
+                meta[Placeholder(body).name] = {"is_conditional": True}
         return meta
 
     @property

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = "48.1.1"
+__version__ = "48.1.2"
 # GDS version '34.0.1'

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -283,6 +283,8 @@ def test_field_renders_lists_as_strings(values, expected, expected_as_markdown):
         ("Lorem ipsum ((var)) Lorem ipsum ((var))", False),
         ("Lorem ipsum ((var??Conditional text))", True),
         ("Lorem ipsum ((var??Conditional text)) ((other_var))", True),
+        ("Lorem ipsum ((var)) Lorem ipsum ((var??Conditional text))", True),
+        ("Lorem ipsum ((var??Conditional text)) Lorem ipsum ((var))", True),
     ],
 )
 def test_placeholder_meta(template_str: str, result: bool):

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -272,3 +272,18 @@ def test_what_will_trigger_conditional_placeholder(value):
 def test_field_renders_lists_as_strings(values, expected, expected_as_markdown):
     assert str(Field("list: ((placeholder))", values, markdown_lists=True)) == expected_as_markdown
     assert str(Field("list: ((placeholder))", values)) == expected
+
+
+@pytest.mark.parametrize(
+    "template_str, result",
+    [
+        ("Lorem ipsum ((var))", False),
+        ("Lorem ipsum ((var??Conditional text))", True),
+        ("Lorem ipsum ((var)) Lorem ipsum ((var??Conditional text)) Lorem ipsum ((var))", True),
+        ("Lorem ipsum ((var)) Lorem ipsum ((var))", False),
+        ("Lorem ipsum ((var??Conditional text))", True),
+        ("Lorem ipsum ((var??Conditional text)) ((other_var))", True),
+    ],
+)
+def test_placeholder_meta(template_str: str, result: bool):
+    assert Field(template_str).placeholders_meta["var"]["is_conditional"] == result


### PR DESCRIPTION
# Summary | Résumé

Closes https://github.com/cds-snc/notification-planning/issues/847

This PR fixes a bug in #128 where the `{"is_conditional": True}` property can be overwritten to `False` if the same variable is used multiple times in a template. The desired behaviour is that, if a variable is used in a conditional statement, we should guide the user towards setting it to a True/False value and always display the radio buttons instead of free text in the "send to one recipient" flow here: https://github.com/cds-snc/notification-admin/pull/1316