### PR TITLE
Remove path:path from waffles

### DIFF
--- a/.github/actions/waffles/waffles.py
+++ b/.github/actions/waffles/waffles.py
@@ -123,6 +123,8 @@ def _get_flask_endpoints(flask_app: Flask) -> List[URL]:
         endpoint = URL(extra_endpoint)
         endpoints.append(endpoint)
 
+    endpoints.remove("/<path:path>")
+
     return sorted(endpoints)
 
 

--- a/.github/actions/waffles/waffles.py
+++ b/.github/actions/waffles/waffles.py
@@ -123,7 +123,7 @@ def _get_flask_endpoints(flask_app: Flask) -> List[URL]:
         endpoint = URL(extra_endpoint)
         endpoints.append(endpoint)
 
-    # We want to remove invalid paths from the endpoint list
+    # Remove flask dynamic path
     if "/<path:path>" in endpoints:
         endpoints.remove("/<path:path>")
 

--- a/.github/actions/waffles/waffles.py
+++ b/.github/actions/waffles/waffles.py
@@ -123,7 +123,8 @@ def _get_flask_endpoints(flask_app: Flask) -> List[URL]:
         endpoint = URL(extra_endpoint)
         endpoints.append(endpoint)
 
-    endpoints.remove("/<path:path>")
+    if "/<path:path>" in endpoints:
+        endpoints.remove("/<path:path>")
 
     return sorted(endpoints)
 

--- a/.github/actions/waffles/waffles.py
+++ b/.github/actions/waffles/waffles.py
@@ -123,6 +123,7 @@ def _get_flask_endpoints(flask_app: Flask) -> List[URL]:
         endpoint = URL(extra_endpoint)
         endpoints.append(endpoint)
 
+    # We want to remove invalid paths from the endpoint list
     if "/<path:path>" in endpoints:
         endpoints.remove("/<path:path>")
 


### PR DESCRIPTION
# Summary | Résumé

When waffles returns valid endpoints from a flask app, we want to remove the route /<path:path> 