### PR TITLE
waffles needs updated utils for api

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 Flask==2.0.3
 markupsafe==2.0.1
-git+https://github.com/cds-snc/notifier-utils.git@48.0.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@48.3.0#egg=notifications-utils


### PR DESCRIPTION
# Summary | Résumé

Waffles needs to update its version of utils to run this branch
https://github.com/cds-snc/notification-api/pull/1589

