### PR TITLE
use number of message parts in RecipientCSV validation

### DIFF
--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -198,16 +198,20 @@ class RecipientCSV:
 
     @property
     def more_sms_rows_than_can_send(self):
+        return self.sms_fragment_count > self.remaining_messages
+
+    @property
+    def sms_fragment_count(self):
         if self.template_type != "sms":
-            return False
+            return 0
         elif self.template is None:
-            return self.more_rows_than_can_send
+            return len(self)
         else:
             num_parts = 0
             for row in self.rows:
                 sms = SMSMessageTemplate(self.template.__dict__, row.personalisation)
                 num_parts += sms.fragment_count
-            return num_parts > self.remaining_messages
+            return num_parts
 
     @property
     def too_many_rows(self):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = "48.4.0"
+__version__ = "49.0.0"
 # GDS version '34.0.1'

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -776,7 +776,7 @@ def test_error_if_too_many_email_recipients():
     assert recipients.more_rows_than_can_send
 
 
-def test_error_if_too_many_sms_messages():
+def test_error_if_too_many_sms_recipients():
     recipients = RecipientCSV(
         "phone number,\n6502532222,\n6502532222,\n6502532222,",
         placeholders=["phone_number"],

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -765,15 +765,50 @@ def test_ignores_leading_whitespace_in_file(character, name):
     assert not recipients.has_errors
 
 
-def test_error_if_too_many_recipients():
+def test_error_if_too_many_email_recipients():
     recipients = RecipientCSV(
-        "phone number,\n6502532222,\n6502532222,\n6502532222,",
-        placeholders=["phone_number"],
-        template_type="sms",
+        "email address,\ntest@test.com,\ntest@test.com,\ntest@test.com,",
+        placeholders=["email_address"],
+        template_type="email",
         remaining_messages=2,
     )
     assert recipients.has_errors
     assert recipients.more_rows_than_can_send
+
+
+def test_error_if_too_many_sms_messages():
+    recipients = RecipientCSV(
+        "phone number,\n6502532222,\n6502532222,\n6502532222,",
+        placeholders=["phone_number"],
+        template_type="sms",
+        template=SMSMessageTemplate(
+            {"content": "test message", "template_type": "sms"},
+            sender=None,
+            prefix=None,
+        ),
+        remaining_messages=2,
+    )
+    assert recipients.has_errors
+    assert recipients.more_sms_rows_than_can_send
+
+
+def test_error_if_too_many_sms_message_parts():
+    recipients = RecipientCSV(
+        "phone number,\n6502532222,",
+        placeholders=["phone_number"],
+        template_type="sms",
+        template=SMSMessageTemplate(
+            {
+                "content": 330 * "a",
+                "template_type": "sms",
+            },
+            sender=None,
+            prefix=None,
+        ),
+        remaining_messages=2,
+    )
+    assert recipients.has_errors
+    assert recipients.more_sms_rows_than_can_send
 
 
 def test_dont_error_if_too_many_recipients_not_specified():
@@ -782,6 +817,7 @@ def test_dont_error_if_too_many_recipients_not_specified():
     )
     assert not recipients.has_errors
     assert not recipients.more_rows_than_can_send
+    assert not recipients.more_sms_rows_than_can_send
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Summary | Résumé

bulk jobs get validated in `RecipientCSV`. Here we use the number of sms message parts in the validation of sms bulk jobs.

# Test instructions | Instructions pour tester la modification

Used in https://github.com/cds-snc/notification-api/pull/1606