### PR TITLE
Fix/lang tags

### DIFF
--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -622,7 +622,7 @@ def escape_lang_tags(_content: str) -> str:
 def add_language_divs(_content: str) -> str:
     """
     Custom parser to add the language divs.
-    
+
     String replace language tags in-place
     """
     _content = _content.replace(FR_OPEN_LITERAL, '<div lang="fr-ca">')

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -612,10 +612,16 @@ def escape_lang_tags(_content: str) -> str:
     Escape language tags into code tags in the content so mistune doesn't put them inside p tags.  This makes it simple
     to replace them afterwards, and avoids creating invalid HTML in the process
     """
-    _content = _content.replace(FR_OPEN_LITERAL, f"\n```\n{FR_OPEN_LITERAL}\n```\n")
-    _content = _content.replace(FR_CLOSE_LITERAL, f"\n```\n{FR_CLOSE_LITERAL}\n```\n")
-    _content = _content.replace(EN_OPEN_LITERAL, f"```\n{EN_OPEN_LITERAL}\n```\n")
-    _content = _content.replace(EN_CLOSE_LITERAL, f"\n```\n{EN_CLOSE_LITERAL}\n```\n")
+
+    # check to ensure we have the same number of opening and closing tags before escaping tags
+    if (_content.count(EN_OPEN_LITERAL) == _content.count(EN_CLOSE_LITERAL)) and (
+        _content.count(FR_OPEN_LITERAL) == _content.count(FR_CLOSE_LITERAL)
+    ):
+        _content = _content.replace(FR_OPEN_LITERAL, f"\n```\n{FR_OPEN_LITERAL}\n```\n")
+        _content = _content.replace(FR_CLOSE_LITERAL, f"\n```\n{FR_CLOSE_LITERAL}\n```\n")
+        _content = _content.replace(EN_OPEN_LITERAL, f"```\n{EN_OPEN_LITERAL}\n```\n")
+        _content = _content.replace(EN_CLOSE_LITERAL, f"\n```\n{EN_CLOSE_LITERAL}\n```\n")
+
     return _content
 
 
@@ -625,10 +631,15 @@ def add_language_divs(_content: str) -> str:
 
     String replace language tags in-place
     """
-    _content = _content.replace(FR_OPEN_LITERAL, '<div lang="fr-ca">')
-    _content = _content.replace(FR_CLOSE_LITERAL, "</div>")
-    _content = _content.replace(EN_OPEN_LITERAL, '<div lang="en-ca">')
-    _content = _content.replace(EN_CLOSE_LITERAL, "</div>")
+
+    # check to ensure we have the same number of opening and closing tags before escaping tags
+    if (_content.count(EN_OPEN_LITERAL) == _content.count(EN_CLOSE_LITERAL)) and (
+        _content.count(FR_OPEN_LITERAL) == _content.count(FR_CLOSE_LITERAL)
+    ):
+        _content = _content.replace(FR_OPEN_LITERAL, '<div lang="fr-ca">')
+        _content = _content.replace(FR_CLOSE_LITERAL, "</div>")
+        _content = _content.replace(EN_OPEN_LITERAL, '<div lang="en-ca">')
+        _content = _content.replace(EN_CLOSE_LITERAL, "</div>")
 
     return _content
 

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -28,6 +28,7 @@ from notifications_utils.formatters import (
     remove_empty_lines,
     sms_encode,
     escape_html,
+    escape_lang_tags,
     strip_dvla_markup,
     strip_pipes,
     remove_whitespace_before_punctuation,
@@ -753,6 +754,7 @@ def get_html_email_body(template_content, template_values, redact_missing_person
         .then(unlink_govuk_escaped)
         .then(strip_unsupported_characters)
         .then(add_trailing_newline)
+        .then(escape_lang_tags)
         .then(notify_email_markdown)
         .then(add_language_divs)
         .then(add_ircc_coat_of_arms)

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = "49.0.0"
+__version__ = "49.1.0"
 # GDS version '34.0.1'

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -3,6 +3,8 @@ import pytest
 from flask import Markup
 
 from notifications_utils.formatters import (
+    EMAIL_P_CLOSE_TAG,
+    EMAIL_P_OPEN_TAG,
     add_ircc_coat_of_arms,
     add_ircc_ga_seal,
     add_ircc_seal,
@@ -962,8 +964,8 @@ def test_normalise_whitespace():
 class TestAddLanguageDivs:
     testCases = (
         (
-            ## newlines after lang tags
-            f"""[[fr]]
+            # newlines after lang tags
+            """[[fr]]
 Le français suis l'anglais
 [[/fr]]
 
@@ -975,21 +977,21 @@ hi
 bonjour
 [[/fr]]
             """,
-            '<div lang="fr-ca"><p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">Le français suis l\'anglais</p></div><div lang="en-ca"><p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">hi</p></div><div lang="fr-ca"><p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">bonjour</p></div>',
+            f'<div lang="fr-ca">{EMAIL_P_OPEN_TAG}Le français suis l\'anglais{EMAIL_P_CLOSE_TAG}</div><div lang="en-ca">{EMAIL_P_OPEN_TAG}hi{EMAIL_P_CLOSE_TAG}</div><div lang="fr-ca">{EMAIL_P_OPEN_TAG}bonjour{EMAIL_P_CLOSE_TAG}</div>',  # noqa
         ),
         (
-            ## no newlines after lang tags
-            f"""[[fr]]Le français suis l'anglais[[/fr]]
+            # no newlines after lang tags
+            """[[fr]]Le français suis l'anglais[[/fr]]
 
 [[en]]hi[[/en]]
 
 [[fr]]bonjour[[/fr]]
             """,
-            '<div lang="fr-ca"><p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">Le français suis l\'anglais</p></div><div lang="en-ca"><p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">hi</p></div><div lang="fr-ca"><p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">bonjour</p></div>',
+            f'<div lang="fr-ca">{EMAIL_P_OPEN_TAG}Le français suis l\'anglais{EMAIL_P_CLOSE_TAG}</div><div lang="en-ca">{EMAIL_P_OPEN_TAG}hi{EMAIL_P_CLOSE_TAG}</div><div lang="fr-ca">{EMAIL_P_OPEN_TAG}bonjour{EMAIL_P_CLOSE_TAG}</div>',  # noqa
         ),
         (
             # with heading tag
-            f"""[[fr]]
+            """[[fr]]
 Le français suis l'anglais
 
 # Heading 1
@@ -1004,7 +1006,7 @@ hi
 [[fr]]
 bonjour
 [[/fr]]""",
-            '<div lang="fr-ca"><p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">Le français suis l\'anglais</p><h2 style="Margin: 0 0 20px 0; padding: 0; font-size: 27px; line-height: 35px; font-weight: bold; color: #0B0C0C;">Heading 1</h2><p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">Hi</p></div><div lang="en-ca"><h3 style="Margin: 0 0 15px 0; padding: 0; line-height: 26px; color: #0B0C0C;font-size: 24px; font-weight: bold;">Heading 2</h3><p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">hi</p></div><div lang="fr-ca"><p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">bonjour</p></div>',
+            f'<div lang="fr-ca">{EMAIL_P_OPEN_TAG}Le français suis l\'anglais{EMAIL_P_CLOSE_TAG}<h2 style="Margin: 0 0 20px 0; padding: 0; font-size: 27px; line-height: 35px; font-weight: bold; color: #0B0C0C;">Heading 1</h2>{EMAIL_P_OPEN_TAG}Hi{EMAIL_P_CLOSE_TAG}</div><div lang="en-ca"><h3 style="Margin: 0 0 15px 0; padding: 0; line-height: 26px; color: #0B0C0C;font-size: 24px; font-weight: bold;">Heading 2</h3>{EMAIL_P_OPEN_TAG}hi{EMAIL_P_CLOSE_TAG}</div><div lang="fr-ca">{EMAIL_P_OPEN_TAG}bonjour{EMAIL_P_CLOSE_TAG}</div>',  # noqa
         ),
         # with list tag
         (
@@ -1025,8 +1027,10 @@ bonjour
 1. item 2
 1. item 3
 [[/fr]]""",
-            '<div lang="fr-ca"><p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">Le français suis l\'anglais</p></div><div lang="en-ca"><table role="presentation" style="padding: 0 0 20px 0;"><tr><td style="font-family: Helvetica, Arial, sans-serif;"><ul style="Margin: 0 0 0 20px; padding: 0; list-style-type: disc;"><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px;line-height: 25px; color: #0B0C0C;">item 1</li><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px;line-height: 25px; color: #0B0C0C;">item 2</li><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px;line-height: 25px; color: #0B0C0C;">item 3</li></ul></td></tr></table></div><div lang="fr-ca"><p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">bonjour</p><table role="presentation" style="padding: 0 0 20px 0;"><tr><td style="font-family: Helvetica, Arial, sans-serif;"><ol style="Margin: 0 0 0 20px; padding: 0; list-style-type: decimal;"><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px;line-height: 25px; color: #0B0C0C;">item 1</li><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px;line-height: 25px; color: #0B0C0C;">item 2</li><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px;line-height: 25px; color: #0B0C0C;">item 3</li></ol></td></tr></table></div>',
+            f'<div lang="fr-ca">{EMAIL_P_OPEN_TAG}Le français suis l\'anglais{EMAIL_P_CLOSE_TAG}</div><div lang="en-ca"><table role="presentation" style="padding: 0 0 20px 0;"><tr><td style="font-family: Helvetica, Arial, sans-serif;"><ul style="Margin: 0 0 0 20px; padding: 0; list-style-type: disc;"><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px;line-height: 25px; color: #0B0C0C;">item 1</li><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px;line-height: 25px; color: #0B0C0C;">item 2</li><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px;line-height: 25px; color: #0B0C0C;">item 3</li></ul></td></tr></table></div><div lang="fr-ca">{EMAIL_P_OPEN_TAG}bonjour{EMAIL_P_CLOSE_TAG}<table role="presentation" style="padding: 0 0 20px 0;"><tr><td style="font-family: Helvetica, Arial, sans-serif;"><ol style="Margin: 0 0 0 20px; padding: 0; list-style-type: decimal;"><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px;line-height: 25px; color: #0B0C0C;">item 1</li><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px;line-height: 25px; color: #0B0C0C;">item 2</li><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px;line-height: 25px; color: #0B0C0C;">item 3</li></ol></td></tr></table></div>',  # noqa
         ),
+        ("[[en]]No closing tag", f"{EMAIL_P_OPEN_TAG}[[en]]No closing tag{EMAIL_P_CLOSE_TAG}"),
+        ("No opening tag[[/en]]", f"{EMAIL_P_OPEN_TAG}No opening tag[[/en]]{EMAIL_P_CLOSE_TAG}"),
     )
 
     @pytest.mark.parametrize(
@@ -1054,16 +1058,13 @@ bonjour
             .then(add_language_divs)
         )
 
-        assert (
-            testString
-            == output  #'<div lang="fr-ca"><p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">Le français suis l\'anglais</p></div><div lang="en-ca"><p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">hi</p></div><div lang="fr-ca"><p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">bonjour</p></div>'  # noqa
-        )
+        assert testString == output
 
     @pytest.mark.parametrize(
         "input",
         (
             # With newlines + nested lang tags
-            f"""[[fr]]
+            """[[fr]]
 Le français suis l'anglais
 [[/fr]]
 
@@ -1079,7 +1080,7 @@ bonjour
 [[/fr]]
             """,
             # Without newlines + nested lang tags
-            f"""[[fr]]Le français suis l'anglais[[/fr]]
+            """[[fr]]Le français suis l'anglais[[/fr]]
 
 [[en]]hi[[fr]]NESTED![[/fr]][[/en]]
 
@@ -1101,7 +1102,7 @@ bonjour
 
         assert (
             testString
-            == '<div lang="fr-ca"><p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">Le français suis l\'anglais</p></div><div lang="en-ca"><p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">hi</p><div lang="fr-ca"><p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">NESTED!</p></div></div><div lang="fr-ca"><p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">bonjour</p></div>'  # noqa
+            == f'<div lang="fr-ca">{EMAIL_P_OPEN_TAG}Le français suis l\'anglais{EMAIL_P_CLOSE_TAG}</div><div lang="en-ca">{EMAIL_P_OPEN_TAG}hi{EMAIL_P_CLOSE_TAG}<div lang="fr-ca">{EMAIL_P_OPEN_TAG}NESTED!{EMAIL_P_CLOSE_TAG}</div></div><div lang="fr-ca">{EMAIL_P_OPEN_TAG}bonjour{EMAIL_P_CLOSE_TAG}</div>'  # noqa
         )
 
 


### PR DESCRIPTION
# Summary | Résumé

This PR fixes issues cause by lang tag replacement.  

Before, the language tags were being replaced in-place in the template, after mistune would run and insert markup.  This lead to invalid markup in certain situations using other formatting features (like headings, lists, etc.)

Instead, now the language tags are marked up as code blocks prior to mistune running, which preserves their order in the markup and keeps them out of the the generated tags that mistune creates.

After mistune runs, its a simple string replacement to turn the lang tags into properly accessible markup (i.e. `<div lang="fr-ca">...</div>`)

