### PR TITLE
Upgrade to Python 3.10

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.9@sha256:30cd5aa1d4c9b36e29676034ae9690ebaab1611eca39146a5e9a058b382992a7
+FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.10
 
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils 2>&1 \

--- a/.github/actions/waffles/Dockerfile
+++ b/.github/actions/waffles/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM python:3.9@sha256:475fe86ebf1da48ea27009a8f7d7e96231af4142de918a68010d48d0abb9c9c5
+FROM python:3.10
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 RUN mkdir app

--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,5 @@
 docopt==0.6.2
 Flask==2.0.3
 markupsafe==2.0.1
-git+https://github.com/cds-snc/notifier-utils.git@48.3.0#egg=notifications-utils
+# git+https://github.com/cds-snc/notifier-utils.git@48.3.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@python-3.10#egg=notifications-utils

--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,5 +1,4 @@
 docopt==0.6.2
 Flask==2.0.3
 markupsafe==2.0.1
-# git+https://github.com/cds-snc/notifier-utils.git@48.3.0#egg=notifications-utils
-git+https://github.com/cds-snc/notifier-utils.git@python-3.10#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@50.0.0#egg=notifications-utils

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,8 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@main
-    - name: docker://python:3.9
-      uses: docker://python:3.9
+    - name: docker://python:3.10
+      uses: docker://python:3.10
       with:
           entrypoint: /bin/bash
           args: -c "/github/workspace/scripts/bootstrap.sh && /github/workspace/scripts/run_tests.sh"

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.10
 check_untyped_defs = True
 exclude = venv|build
 

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -1,7 +1,7 @@
 import re
 from typing import Any, Callable, Dict, List, Literal
 
-from orderedset import OrderedSet
+from ordered_set import OrderedSet
 from flask import Markup
 
 from notifications_utils.columns import Columns

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -8,7 +8,7 @@ from contextlib import suppress
 from functools import lru_cache, partial
 from itertools import islice
 from collections import OrderedDict, namedtuple
-from orderedset import OrderedSet
+from ordered_set import OrderedSet
 from typing import Callable, Dict, List
 
 from flask import current_app

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -1,2 +1,2 @@
-__version__ = "49.1.0"
+__version__ = "50.0.0"
 # GDS version '34.0.1'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.black]
 line-length = 130
-target-version = ['py37', 'py38', 'py39']
+target-version = ['py37', 'py38', 'py39', 'py310']
 include = '(notifications_utils|tests)/.*\.pyi?$'

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -8,5 +8,5 @@ requests-mock==1.9.3
 flake8==3.9.2
 flake8-print==4.0.1
 mypy==0.812
-black==21.5b2
+black==22.10.0
 click==8.0.1

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "requests==2.25.1",
         "python-json-logger==2.0.4",
         "Flask==2.0.3",
-        "orderedset==2.0.3",
+        "ordered-set==4.1.0",
         "markupsafe==2.0.1",
         "Jinja2>3.0.0",
         "statsd==3.3.0",

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -2,7 +2,7 @@ import pytest
 import itertools
 import unicodedata
 from functools import partial
-from orderedset import OrderedSet
+from ordered_set import OrderedSet
 
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
 from notifications_utils.recipients import Cell, RecipientCSV, Row


### PR DESCRIPTION
# Summary | Résumé

https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/cds-snc/notification-planning/959
Upgrade Python from 3.9 to 3.10

Notes:
- need to switch from the library orderedset to ordered_set since the former does not support 3.10 and is possibly abandonware.

# Test instructions | Instructions pour tester la modification

See if this utils works with upgraded apps:
admin: https://github.com/cds-snc/notification-admin/pull/1400
api:
document-download-api:

