### PR TITLE
log last 2 characters of sensitive values

### DIFF
--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -143,6 +143,24 @@ def configure_handler(handler, app, formatter):
     return handler
 
 
+# def get_class_attrs(cls, sensitive_attrs: list[str]) -> dict[str, Any]:
+#     """
+#     Returns a dict of Class attribute key/values.  Any attribute names in the
+#     sensitive_attrs list will be masked.
+#     """
+#     attrs = {}
+#     for attr in dir(cls):
+#         if not attr.startswith("__") and not callable(getattr(cls, attr)):
+#             value = getattr(cls, attr)
+#             if attr not in sensitive_attrs:
+#                 attrs[attr] = value
+#             elif len(str(value)) >= 20:
+#                 attrs[attr] = "***" + str(value)[-2:]
+#             else:
+#                 attrs[attr] = "***"
+#     return attrs
+
+
 def get_class_attrs(cls, sensitive_attrs: list[str]) -> dict[str, Any]:
     """
     Returns a dict of Class attribute key/values.  Any attribute names in the
@@ -152,12 +170,8 @@ def get_class_attrs(cls, sensitive_attrs: list[str]) -> dict[str, Any]:
     for attr in dir(cls):
         if not attr.startswith("__") and not callable(getattr(cls, attr)):
             value = getattr(cls, attr)
-            if attr not in sensitive_attrs:
-                attrs[attr] = value
-            elif len(str(value)) >= 20:
-                attrs[attr] = "***" + str(value)[-2:]
-            else:
-                attrs[attr] = "***"
+            if attr in sensitive_attrs:
+                attrs[attr] = len(str(value))
     return attrs
 
 

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -150,7 +150,7 @@ def get_class_attrs(cls, sensitive_attrs: list[str]) -> dict[str, Any]:
     """
     attrs = {}
     for attr in dir(cls):
-        attr_value = "***" if attr in sensitive_attrs else getattr(cls, attr)
+        attr_value = "***" + f"{getattr(cls, attr)}"[-4:] if attr in sensitive_attrs else getattr(cls, attr)
         if not attr.startswith("__") and not callable(attr_value):
             attrs[attr] = attr_value
     return attrs

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -150,9 +150,14 @@ def get_class_attrs(cls, sensitive_attrs: list[str]) -> dict[str, Any]:
     """
     attrs = {}
     for attr in dir(cls):
-        attr_value = "***" + f"{getattr(cls, attr)}"[-4:] if attr in sensitive_attrs else getattr(cls, attr)
-        if not attr.startswith("__") and not callable(attr_value):
-            attrs[attr] = attr_value
+        if not attr.startswith("__") and not callable(getattr(cls, attr)):
+            value = getattr(cls, attr)
+            if attr not in sensitive_attrs:
+                attrs[attr] = value
+            elif len(str(value)) >= 20:
+                attrs[attr] = "***" + str(value)[-2:]
+            else:
+                attrs[attr] = "***"
     return attrs
 
 

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -143,24 +143,6 @@ def configure_handler(handler, app, formatter):
     return handler
 
 
-# def get_class_attrs(cls, sensitive_attrs: list[str]) -> dict[str, Any]:
-#     """
-#     Returns a dict of Class attribute key/values.  Any attribute names in the
-#     sensitive_attrs list will be masked.
-#     """
-#     attrs = {}
-#     for attr in dir(cls):
-#         if not attr.startswith("__") and not callable(getattr(cls, attr)):
-#             value = getattr(cls, attr)
-#             if attr not in sensitive_attrs:
-#                 attrs[attr] = value
-#             elif len(str(value)) >= 20:
-#                 attrs[attr] = "***" + str(value)[-2:]
-#             else:
-#                 attrs[attr] = "***"
-#     return attrs
-
-
 def get_class_attrs(cls, sensitive_attrs: list[str]) -> dict[str, Any]:
     """
     Returns a dict of Class attribute key/values.  Any attribute names in the
@@ -170,8 +152,12 @@ def get_class_attrs(cls, sensitive_attrs: list[str]) -> dict[str, Any]:
     for attr in dir(cls):
         if not attr.startswith("__") and not callable(getattr(cls, attr)):
             value = getattr(cls, attr)
-            if attr in sensitive_attrs:
-                attrs[attr] = len(str(value))
+            if attr not in sensitive_attrs:
+                attrs[attr] = value
+            elif len(str(value)) >= 20:
+                attrs[attr] = "***" + str(value)[-2:]
+            else:
+                attrs[attr] = "***"
     return attrs
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = '(notifications_utils|tests)/.*\.pyi?$'
 
 [tool.poetry]
 name = "notifications-utils"
-version = "50.1.9"
+version = "50.1.10"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -161,7 +161,7 @@ def test_logging_records_statsd_stats_without_time(app_with_statsd, service_id):
             statsd.timing.assert_not_called()
 
 
-def test_get_class_attr():
+def test_get_class_attrs():
     class Config:
         some_dict = {
             "FOO": "bar",

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -168,6 +168,7 @@ def test_get_class_attrs():
             "BAM": "baz",
         }
         env = "prod"
+        secret = "secret value"
 
         def some_function(self):
             return True
@@ -178,16 +179,18 @@ def test_get_class_attrs():
             "BAM": "baz",
         },
         "env": "prod",
+        "secret": "secret value",
     }
 
     an_instance = Config()
     an_instance.some_dict = {"BAR": "bloop"}
 
-    assert logging.get_class_attrs(an_instance, ["env"]) == {
+    assert logging.get_class_attrs(an_instance, ["secret"]) == {
         "some_dict": {
             "BAR": "bloop",
         },
-        "env": "***",
+        "env": "prod",
+        "secret": "***alue",
     }
 
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -161,36 +161,27 @@ def test_logging_records_statsd_stats_without_time(app_with_statsd, service_id):
             statsd.timing.assert_not_called()
 
 
-def test_get_class_attrs():
+def test_get_class_attr():
     class Config:
         some_dict = {
             "FOO": "bar",
             "BAM": "baz",
         }
         env = "prod"
-        secret = "secret value"
+        secret19 = "19 long secret 1234"
+        secret20 = "20 long secret 12345"
 
         def some_function(self):
             return True
 
-    assert logging.get_class_attrs(Config, []) == {
+    assert logging.get_class_attrs(Config, ["secret19", "secret20"]) == {
         "some_dict": {
             "FOO": "bar",
             "BAM": "baz",
         },
         "env": "prod",
-        "secret": "secret value",
-    }
-
-    an_instance = Config()
-    an_instance.some_dict = {"BAR": "bloop"}
-
-    assert logging.get_class_attrs(an_instance, ["secret"]) == {
-        "some_dict": {
-            "BAR": "bloop",
-        },
-        "env": "prod",
-        "secret": "***alue",
+        "secret19": "***",
+        "secret20": "***45",
     }
 
 


### PR DESCRIPTION
# Summary | Résumé

Currently we log the config when admin or api boots. However we redact the secrets. This makes the logging not very useful in ensuring that we're using the correct secrets 😅 

In this PR we change this so that if a secret has length >= 20 we log the last 2 digits.

Tested by using this branch on api and when booting see things like
```
'DANGEROUS_SALT': '***wm'
```
# Test instructions | Instructions pour tester la modification

Can use this branch with api or admin to see the new behaviour on startup. Change your `pyproject.toml` to install utils with
```
notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", branch = "show-part-of-sensitive-values"}
```
