### PR TITLE
Add seeding complete flag

### DIFF
--- a/notifications_utils/clients/redis/bounce_rate.py
+++ b/notifications_utils/clients/redis/bounce_rate.py
@@ -11,8 +11,10 @@ def hard_bounce_key(service_id: str):
 def total_notifications_key(service_id: str):
     return f"sliding_total_notifications:{service_id}"
 
+
 def seeding_complete_key(service_id: str):
     return f"seeding_complete:{service_id}"
+
 
 def _twenty_four_hour_window_ms() -> int:
     return 24 * 60 * 60 * 1000
@@ -43,13 +45,13 @@ class RedisBounceRate:
     def set_seeding_complete(self, service_id: str) -> None:
         """Call this after seeding data in Redis"""
         self._redis_client.set(seeding_complete_key(service_id), "True")
-        
+
     def get_seeding_complete(self, service_id: str) -> bool:
         """Returns True if seeding is complete, False otherwise"""
         if self._redis_client.get(seeding_complete_key(service_id)) == b"True":
             return True
         return False
-        
+
     def get_bounce_rate(self, service_id: str, bounce_window=_twenty_four_hour_window_ms()) -> float:
         """Returns the bounce rate for a service in the last 24 hours, and deletes data older than 24 hours"""
         now = _current_timestamp_ms()

--- a/notifications_utils/clients/redis/bounce_rate.py
+++ b/notifications_utils/clients/redis/bounce_rate.py
@@ -3,6 +3,8 @@ from datetime import datetime
 
 from notifications_utils.clients.redis.redis_client import RedisClient
 
+TWENTY_FOUR_HOURS_IN_SECONDS = 24 * 60 * 60
+
 
 def hard_bounce_key(service_id: str):
     return f"sliding_hard_bounce:{service_id}"
@@ -45,13 +47,14 @@ class RedisBounceRate:
     def set_seeding_complete(self, service_id: str) -> None:
         """Call this after seeding data in Redis"""
         self._redis_client.set(seeding_complete_key(service_id), "True")
+        self._redis_client.expire(seeding_complete_key(service_id), TWENTY_FOUR_HOURS_IN_SECONDS)
 
     def get_seeding_complete(self, service_id: str) -> bool:
         """Returns True if seeding is complete, False otherwise"""
         if self._redis_client.get(seeding_complete_key(service_id)) == b"True":
             return True
         return False
-    
+
     def clear_bounce_rate_data(self, service_id: str) -> None:
         """Clears all data for a service before seeding new data"""
         self._redis_client.delete(hard_bounce_key(service_id))

--- a/notifications_utils/clients/redis/bounce_rate.py
+++ b/notifications_utils/clients/redis/bounce_rate.py
@@ -51,6 +51,11 @@ class RedisBounceRate:
         if self._redis_client.get(seeding_complete_key(service_id)) == b"True":
             return True
         return False
+    
+    def clear_bounce_rate_data(self, service_id: str) -> None:
+        """Clears all data for a service before seeding new data"""
+        self._redis_client.delete(hard_bounce_key(service_id))
+        self._redis_client.delete(total_notifications_key(service_id))
 
     def get_bounce_rate(self, service_id: str, bounce_window=_twenty_four_hour_window_ms()) -> float:
         """Returns the bounce rate for a service in the last 24 hours, and deletes data older than 24 hours"""

--- a/notifications_utils/clients/redis/bounce_rate.py
+++ b/notifications_utils/clients/redis/bounce_rate.py
@@ -14,8 +14,8 @@ def total_notifications_key(service_id: str):
     return f"sliding_total_notifications:{service_id}"
 
 
-def seeding_complete_key(service_id: str):
-    return f"seeding_complete:{service_id}"
+def seeding_started_key(service_id: str):
+    return f"seeding_started:{service_id}"
 
 
 def _twenty_four_hour_window_ms() -> int:
@@ -44,14 +44,14 @@ class RedisBounceRate:
     def set_hard_bounce_seeded(self, service_id: str, seeded_data: dict) -> None:
         self._redis_client.add_data_to_sorted_set(hard_bounce_key(service_id), seeded_data)
 
-    def set_seeding_complete(self, service_id: str) -> None:
-        """Call this after seeding data in Redis"""
-        self._redis_client.set(seeding_complete_key(service_id), "True")
-        self._redis_client.expire(seeding_complete_key(service_id), TWENTY_FOUR_HOURS_IN_SECONDS)
+    def set_seeding_started(self, service_id: str) -> None:
+        """Set a flag in Redis to indicate that we have started to seed data for a given service"""
+        self._redis_client.set(seeding_started_key(service_id), "True")
+        self._redis_client.expire(seeding_started_key(service_id), TWENTY_FOUR_HOURS_IN_SECONDS)
 
-    def get_seeding_complete(self, service_id: str) -> bool:
+    def get_seeding_started(self, service_id: str) -> bool:
         """Returns True if seeding is complete, False otherwise"""
-        if self._redis_client.get(seeding_complete_key(service_id)) == b"True":
+        if self._redis_client.get(seeding_started_key(service_id)) == b"True":
             return True
         return False
 

--- a/notifications_utils/clients/redis/bounce_rate.py
+++ b/notifications_utils/clients/redis/bounce_rate.py
@@ -11,6 +11,8 @@ def hard_bounce_key(service_id: str):
 def total_notifications_key(service_id: str):
     return f"sliding_total_notifications:{service_id}"
 
+def seeding_complete_key(service_id: str):
+    return f"seeding_complete:{service_id}"
 
 def _twenty_four_hour_window_ms() -> int:
     return 24 * 60 * 60 * 1000
@@ -38,6 +40,16 @@ class RedisBounceRate:
     def set_hard_bounce_seeded(self, service_id: str, seeded_data: dict) -> None:
         self._redis_client.add_data_to_sorted_set(hard_bounce_key(service_id), seeded_data)
 
+    def set_seeding_complete(self, service_id: str) -> None:
+        """Call this after seeding data in Redis"""
+        self._redis_client.set(seeding_complete_key(service_id), "True")
+        
+    def get_seeding_complete(self, service_id: str) -> bool:
+        """Returns True if seeding is complete, False otherwise"""
+        if self._redis_client.get(seeding_complete_key(service_id)) == b"True":
+            return True
+        return False
+        
     def get_bounce_rate(self, service_id: str, bounce_window=_twenty_four_hour_window_ms()) -> float:
 
         now = _current_timestamp_ms()

--- a/notifications_utils/clients/redis/bounce_rate.py
+++ b/notifications_utils/clients/redis/bounce_rate.py
@@ -50,7 +50,7 @@ class RedisBounceRate:
         self._redis_client.expire(seeding_started_key(service_id), TWENTY_FOUR_HOURS_IN_SECONDS)
 
     def get_seeding_started(self, service_id: str) -> bool:
-        """Returns True if seeding is complete, False otherwise"""
+        """Returns True if seeding is has already started, False otherwise"""
         if self._redis_client.get(seeding_started_key(service_id)) == b"True":
             return True
         return False

--- a/notifications_utils/clients/redis/bounce_rate.py
+++ b/notifications_utils/clients/redis/bounce_rate.py
@@ -51,7 +51,7 @@ class RedisBounceRate:
         return False
         
     def get_bounce_rate(self, service_id: str, bounce_window=_twenty_four_hour_window_ms()) -> float:
-
+        """Returns the bounce rate for a service in the last 24 hours, and deletes data older than 24 hours"""
         now = _current_timestamp_ms()
         twenty_four_hours_ago = now - bounce_window
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = '(notifications_utils|tests)/.*\.pyi?$'
 
 [tool.poetry]
 name = "notifications-utils"
-version = "50.2.3"
+version = "50.2.4"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_bounce_rate.py
+++ b/tests/test_bounce_rate.py
@@ -119,10 +119,10 @@ class TestRedisBounceRate:
             total_notifications_key(mocked_service_id), seeded_data
         )
 
-    def test_seeding_complete_flag(self, better_mocked_bounce_rate_client, mocked_service_id):
-        assert better_mocked_bounce_rate_client.get_seeding_complete(mocked_service_id) is False
-        better_mocked_bounce_rate_client.set_seeding_complete(mocked_service_id)
-        assert better_mocked_bounce_rate_client.get_seeding_complete(mocked_service_id)
+    def test_seeding_started_flag(self, better_mocked_bounce_rate_client, mocked_service_id):
+        assert better_mocked_bounce_rate_client.get_seeding_started(mocked_service_id) is False
+        better_mocked_bounce_rate_client.set_seeding_started(mocked_service_id)
+        assert better_mocked_bounce_rate_client.get_seeding_started(mocked_service_id)
 
     def test_clear_bounce_rate_data(self, better_mocked_bounce_rate_client, mocked_service_id):
         better_mocked_bounce_rate_client.set_sliding_notifications(mocked_service_id)

--- a/tests/test_bounce_rate.py
+++ b/tests/test_bounce_rate.py
@@ -48,7 +48,7 @@ def mocked_bounce_rate_client(mocked_redis_client, mocker):
 @pytest.fixture(scope="function")
 def better_mocked_bounce_rate_client(better_mocked_redis_client, mocker):
     return RedisBounceRate(better_mocked_redis_client)
-    
+
 
 @pytest.fixture(scope="function")
 def mocked_seeded_data_hours():
@@ -127,7 +127,7 @@ class TestRedisBounceRate:
     def test_clear_bounce_rate_data(self, better_mocked_bounce_rate_client, mocked_service_id):
         better_mocked_bounce_rate_client.set_sliding_notifications(mocked_service_id)
         better_mocked_bounce_rate_client.set_sliding_hard_bounce(mocked_service_id)
- 
+
         total_hard_bounces = better_mocked_bounce_rate_client._redis_client.get_length_of_sorted_set(
             hard_bounce_key(mocked_service_id), min_score=0, max_score="+inf"
         )
@@ -136,9 +136,9 @@ class TestRedisBounceRate:
             total_notifications_key(mocked_service_id), min_score=0, max_score="+inf"
         )
         assert total_notifications == 1
-   
+
         better_mocked_bounce_rate_client.clear_bounce_rate_data(mocked_service_id)
-        
+
         total_hard_bounces = better_mocked_bounce_rate_client._redis_client.get_length_of_sorted_set(
             hard_bounce_key(mocked_service_id), min_score=0, max_score="+inf"
         )


### PR DESCRIPTION
# Summary | Résumé

This PR adds a "seeding complete" flag for each service to Redis, so that we don't try to seed the data twice.
Also adds a `clear_bounce_rate_data` method to call before seeding the data.

See below for how these methods would be used:
- https://github.com/cds-snc/notification-api/pull/1834/files#diff-cca5917c620894fe770faa88835e9e186285d5b91a55fca992eb94d5dc87e635R823
- https://github.com/cds-snc/notification-api/pull/1834/files#diff-cca5917c620894fe770faa88835e9e186285d5b91a55fca992eb94d5dc87e635R850