### PR TITLE
Add a minimum volume check when returning a service's bounce rate

### DIFF
--- a/notifications_utils/clients/redis/bounce_rate.py
+++ b/notifications_utils/clients/redis/bounce_rate.py
@@ -6,6 +6,7 @@ from notifications_utils.clients.redis.redis_client import RedisClient
 TWENTY_FOUR_HOURS_IN_SECONDS = 24 * 60 * 60
 DEFAULT_VOLUME_THRESHOLD = 1000
 
+
 def hard_bounce_key(service_id: str):
     return f"sliding_hard_bounce:{service_id}"
 
@@ -27,7 +28,6 @@ def _current_timestamp_ms() -> int:
 
 
 class RedisBounceRate:
-
     def __init__(self, redis: RedisClient):
         self._redis_client = redis
 
@@ -83,12 +83,14 @@ class RedisBounceRate:
             total_notifications_key(service_id), min_score=twenty_four_hours_ago, max_score=now
         )
 
-        if (total_notifications < 1):
+        if total_notifications < 1:
             return 0.0
 
         return round(total_hard_bounces / (1.0 * total_notifications), 2)
 
-    def check_bounce_rate_status(self, service_id: str, volume_threshold: int = DEFAULT_VOLUME_THRESHOLD, bounce_window=_twenty_four_hour_window_ms()):
+    def check_bounce_rate_status(
+        self, service_id: str, volume_threshold: int = DEFAULT_VOLUME_THRESHOLD, bounce_window=_twenty_four_hour_window_ms()
+    ):
         now = _current_timestamp_ms()
         twenty_four_hours_ago = now - bounce_window
         bounce_rate = self.get_bounce_rate(service_id)

--- a/notifications_utils/clients/redis/bounce_rate.py
+++ b/notifications_utils/clients/redis/bounce_rate.py
@@ -5,6 +5,8 @@ from notifications_utils.clients.redis.redis_client import RedisClient
 
 TWENTY_FOUR_HOURS_IN_SECONDS = 24 * 60 * 60
 DEFAULT_VOLUME_THRESHOLD = 1000
+BR_CRITICAL_PERCENTAGE_DEFAULT = 0.1
+BR_WARNING_PERCENTAGE_DEFAULT = 0.05
 
 
 def hard_bounce_key(service_id: str):
@@ -32,8 +34,14 @@ class RedisBounceRate:
         self._redis_client = redis
 
     def init_app(self, app, *args, **kwargs):
-        self._critical_threshold = app.config.get("BR_CRITICAL_PERCENTAGE")
-        self._warning_threshold = app.config.get("BR_WARNING_PERCENTAGE")
+        self._critical_threshold = (
+            app.config.get("BR_CRITICAL_PERCENTAGE")
+            if app.config.get("BR_CRITICAL_PERCENTAGE")
+            else BR_CRITICAL_PERCENTAGE_DEFAULT
+        )
+        self._warning_threshold = (
+            app.config.get("BR_WARNING_PERCENTAGE") if app.config.get("BR_WARNING_PERCENTAGE") else BR_WARNING_PERCENTAGE_DEFAULT
+        )
 
     def set_sliding_notifications(self, service_id: str) -> None:
         current_time = _current_timestamp_ms()

--- a/notifications_utils/clients/redis/bounce_rate.py
+++ b/notifications_utils/clients/redis/bounce_rate.py
@@ -23,6 +23,10 @@ def _current_timestamp_ms() -> int:
 class RedisBounceRate:
     def __init__(self, redis: RedisClient):
         self._redis_client = redis
+        self.minimum_volume = 1000
+
+    def init_app(self, app, *args, **kwargs):
+        self.minimum_volume = app.config.get("BR_DISPLAY_VOLUME_MINIMUM")
 
     def set_sliding_notifications(self, service_id: str) -> None:
         current_time = _current_timestamp_ms()
@@ -56,4 +60,4 @@ class RedisBounceRate:
             total_notifications_key(service_id), min_score=twenty_four_hours_ago, max_score=now
         )
 
-        return round(total_hard_bounces / (1.0 * total_notifications), 2) if (total_notifications > 0) else 0.0
+        return round(total_hard_bounces / (1.0 * total_notifications), 2) if (total_notifications >= self.minimum_volume) else 0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = '(notifications_utils|tests)/.*\.pyi?$'
 
 [tool.poetry]
 name = "notifications-utils"
-version = "50.2.4"
+version = "50.2.5"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_bounce_rate.py
+++ b/tests/test_bounce_rate.py
@@ -64,9 +64,7 @@ def mocked_seeded_data_hours():
 def build_bounce_rate_client(mocker, better_mocked_redis_client):
     bounce_rate_client = RedisBounceRate(better_mocked_redis_client)
     mocker.patch.object(bounce_rate_client._redis_client, "add_data_to_sorted_set")
-    mocker.patch.object(
-        bounce_rate_client._redis_client, "get_length_of_sorted_set", side_effect=[8, 20, 0, 0, 0, 8, 10, 20]
-    )
+    mocker.patch.object(bounce_rate_client._redis_client, "get_length_of_sorted_set", side_effect=[8, 20, 0, 0, 0, 8, 10, 20])
     mocker.patch.object(bounce_rate_client._redis_client, "expire")
     return bounce_rate_client
 
@@ -104,7 +102,6 @@ class TestRedisBounceRate:
 
         answer = mocked_bounce_rate_client.get_bounce_rate(mocked_service_id)
         assert answer == 0.5
-
 
     def test_set_total_hard_bounce_seeded(
         self,
@@ -153,7 +150,6 @@ class TestRedisBounceRate:
         )
         assert total_notifications == 0
 
-
     @pytest.mark.parametrize(
         "total_bounces, total_notifications, expected_status, volume_threshold",
         [
@@ -162,10 +158,18 @@ class TestRedisBounceRate:
             (0, 100, "normal", 75),
             (0, 0, "normal", 75),
             (0, 1, "normal", 75),
-            (1, 1, "normal", 75)
-        ]
+            (1, 1, "normal", 75),
+        ],
     )
-    def test_check_bounce_rate_critical(app, better_mocked_bounce_rate_client, mocked_service_id, total_bounces, total_notifications, expected_status, volume_threshold):
+    def test_check_bounce_rate_critical(
+        app,
+        better_mocked_bounce_rate_client,
+        mocked_service_id,
+        total_bounces,
+        total_notifications,
+        expected_status,
+        volume_threshold,
+    ):
         better_mocked_bounce_rate_client._critical_threshold = 0.1
         better_mocked_bounce_rate_client._warning_threshold = 0.05
         better_mocked_bounce_rate_client.clear_bounce_rate_data(mocked_service_id)
@@ -177,6 +181,7 @@ class TestRedisBounceRate:
         better_mocked_bounce_rate_client.set_notifications_seeded(mocked_service_id, dict(notification_data))
         better_mocked_bounce_rate_client.set_hard_bounce_seeded(mocked_service_id, dict(bounce_data))
 
-        bounce_status = better_mocked_bounce_rate_client.check_bounce_rate_status(mocked_service_id, volume_threshold=volume_threshold)
+        bounce_status = better_mocked_bounce_rate_client.check_bounce_rate_status(
+            mocked_service_id, volume_threshold=volume_threshold
+        )
         assert bounce_status == expected_status
-

--- a/tests/test_bounce_rate.py
+++ b/tests/test_bounce_rate.py
@@ -48,7 +48,9 @@ def mocked_seeded_data_hours():
 def build_bounce_rate_client(app, mocker, mocked_redis_client):
     bounce_rate_client = RedisBounceRate(mocked_redis_client)
     mocker.patch.object(bounce_rate_client._redis_client, "add_data_to_sorted_set")
-    mocker.patch.object(bounce_rate_client._redis_client, "get_length_of_sorted_set", side_effect=[408, 1020, 0, 0, 0, 1008, 510, 1020, 5, 10 ])
+    mocker.patch.object(
+        bounce_rate_client._redis_client, "get_length_of_sorted_set", side_effect=[408, 1020, 0, 0, 0, 1008, 510, 1020, 5, 10]
+    )
     mocker.patch.object(bounce_rate_client._redis_client, "expire")
     return bounce_rate_client
 
@@ -89,7 +91,6 @@ class TestRedisBounceRate:
 
         answer = mocked_bounce_rate_client.get_bounce_rate(mocked_service_id)
         assert answer == 0
-
 
     def test_set_total_hard_bounce_seeded(
         self,


### PR DESCRIPTION
# Summary | Résumé
Add a new method to check the current bounce status of a service. This method takes into account the minimum required 
volume of notifications threshold, only returning a status other than normal if the threshold is met.

Once merged, both `Admin` and `API` will need to be updated to call the client's `init_app` method during their initialization. API should be ready to go with [this PR](https://github.com/cds-snc/notification-api/pull/1837/commits/71189b59bf2302c7e5a19ce83a857de3b7325599) in that regard.