### PR TITLE
Use utcnow() instead of now(), remove rounding

### DIFF
--- a/notifications_utils/clients/redis/bounce_rate.py
+++ b/notifications_utils/clients/redis/bounce_rate.py
@@ -26,7 +26,7 @@ def _twenty_four_hour_window_ms() -> int:
 
 
 def _current_timestamp_ms() -> int:
-    return int(datetime.now().timestamp() * 1000.0)
+    return int(datetime.utcnow().timestamp() * 1000.0)
 
 
 class RedisBounceRate:
@@ -94,7 +94,7 @@ class RedisBounceRate:
         if total_notifications < 1:
             return 0.0
 
-        return round(total_hard_bounces / (1.0 * total_notifications), 2)
+        return total_hard_bounces / (1.0 * total_notifications)
 
     def check_bounce_rate_status(
         self, service_id: str, volume_threshold: int = DEFAULT_VOLUME_THRESHOLD, bounce_window=_twenty_four_hour_window_ms()

--- a/tests/test_bounce_rate.py
+++ b/tests/test_bounce_rate.py
@@ -93,9 +93,9 @@ class TestRedisBounceRate:
         [
             (10, 100, 0.1),
             (5, 100, 0.05),
-            (5, 1000, 0.01),  # inexact b/c we are rounding to 2 decimal places
-            (5, 10000, 0.0),  # inexact b/c we are rounding to 2 decimal places
-            (5, 100000, 0.0),  # inexact b/c we are rounding to 2 decimal places
+            (5, 1000, 0.005),  # inexact b/c we are rounding to 2 decimal places
+            (5, 10000, 0.0005),  # inexact b/c we are rounding to 2 decimal places
+            (5, 100000, 0.00005),  # inexact b/c we are rounding to 2 decimal places
             (0, 100, 0),
             (40, 100, 0.4),
             (0, 0, 0),

--- a/tests/test_bounce_rate.py
+++ b/tests/test_bounce_rate.py
@@ -93,9 +93,9 @@ class TestRedisBounceRate:
         [
             (10, 100, 0.1),
             (5, 100, 0.05),
-            (5, 1000, 0.005),  # inexact b/c we are rounding to 2 decimal places
-            (5, 10000, 0.0005),  # inexact b/c we are rounding to 2 decimal places
-            (5, 100000, 0.00005),  # inexact b/c we are rounding to 2 decimal places
+            (5, 1000, 0.005),
+            (5, 10000, 0.0005),
+            (5, 100000, 0.00005),
             (0, 100, 0),
             (40, 100, 0.4),
             (0, 0, 0),


### PR DESCRIPTION
# Summary | Résumé
- To ensure there are no possibilities of system clock difference, use `utcnow()` when setting `_current_timestamp_ms`.
- `get_bounce_rate` now no longer rounds the result.