### PR TITLE
Switch timestamps from milliseconds to seconds and add a fn for debugging

### DIFF
--- a/tests/test_bounce_rate.py
+++ b/tests/test_bounce_rate.py
@@ -6,7 +6,7 @@ import fakeredis
 from freezegun import freeze_time
 
 from notifications_utils.clients.redis.bounce_rate import (
-    _current_timestamp_ms,
+    _current_timestamp_s,
     RedisBounceRate,
     hard_bounce_key,
     total_notifications_key,
@@ -55,7 +55,7 @@ def better_mocked_bounce_rate_client(better_mocked_redis_client, mocker):
 @pytest.fixture(scope="function")
 def mocked_seeded_data_hours():
     hour_delta = datetime.timedelta(hours=1)
-    hours = [datetime.datetime.now() - hour_delta]
+    hours = [datetime.datetime.utcnow() - hour_delta]
     for i in range(23):
         hours.append(hours[i] - hour_delta)
     return hours
@@ -78,14 +78,14 @@ class TestRedisBounceRate:
     def test_set_hard_bounce(self, mocked_bounce_rate_client, mocked_service_id):
         mocked_bounce_rate_client.set_sliding_hard_bounce(mocked_service_id)
         mocked_bounce_rate_client._redis_client.add_data_to_sorted_set.assert_called_with(
-            hard_bounce_key(mocked_service_id), {_current_timestamp_ms(): _current_timestamp_ms()}
+            hard_bounce_key(mocked_service_id), {_current_timestamp_s(): _current_timestamp_s()}
         )
 
     @freeze_time("2001-01-01 12:00:00.000000")
     def test_set_total_notifications(self, mocked_bounce_rate_client, mocked_service_id):
         mocked_bounce_rate_client.set_sliding_notifications(mocked_service_id)
         mocked_bounce_rate_client._redis_client.add_data_to_sorted_set.assert_called_with(
-            total_notifications_key(mocked_service_id), {_current_timestamp_ms(): _current_timestamp_ms()}
+            total_notifications_key(mocked_service_id), {_current_timestamp_s(): _current_timestamp_s()}
         )
 
     @pytest.mark.parametrize(
@@ -95,7 +95,6 @@ class TestRedisBounceRate:
             (5, 100, 0.05),
             (5, 1000, 0.005),
             (5, 10000, 0.0005),
-            (5, 100000, 0.00005),
             (0, 100, 0),
             (40, 100, 0.4),
             (0, 0, 0),
@@ -108,7 +107,7 @@ class TestRedisBounceRate:
     ):
 
         better_mocked_bounce_rate_client.clear_bounce_rate_data(mocked_service_id)
-        now = int(datetime.datetime.now().timestamp() * 1000.0)
+        now = int(datetime.datetime.utcnow().timestamp())
 
         notification_data = [(now - n, now - n) for n in range(total_notifications)]
         bounce_data = [(now - n, now - n) for n in range(total_bounces)]
@@ -189,7 +188,7 @@ class TestRedisBounceRate:
         better_mocked_bounce_rate_client._critical_threshold = 0.1
         better_mocked_bounce_rate_client._warning_threshold = 0.05
         better_mocked_bounce_rate_client.clear_bounce_rate_data(mocked_service_id)
-        now = int(datetime.datetime.now().timestamp() * 1000.0)
+        now = int(datetime.datetime.utcnow().timestamp())
 
         notification_data = [(now - n, now - n) for n in range(total_notifications)]
         bounce_data = [(now - n, now - n) for n in range(total_bounces)]


### PR DESCRIPTION
# Summary | Résumé

This PR does 2 things:
- Switch timestamps from milliseconds to seconds - we don't need to use ms any more since we are using a `uuid` for our keys inside the sorted sets, and seconds will probably be less error prone
- add a function called `get_debug_data` that will pass some data to notification-api that we can log and may help us figure out our current bugs. This function should be removed later when we no longer need it. 