### PR TITLE
Tweak token code

### DIFF
--- a/notifications_utils/url_safe_token.py
+++ b/notifications_utils/url_safe_token.py
@@ -7,7 +7,7 @@ def generate_token(payload, secret, salt="token"):
     return url_encode_full_stops(URLSafeTimedSerializer(secret).dumps(payload, "token"))
 
 
-# After a day, all valid tokens will be signed with the salt "token" instead of DANGEROUS_SALT.
+# After two days all valid tokens will be signed with the salt "token" instead of DANGEROUS_SALT.
 # So we can:
 #  - stop passing the salt to check_token() in api
 #  - remove the "try / except" block below (and just return the ser.loads())

--- a/notifications_utils/url_safe_token.py
+++ b/notifications_utils/url_safe_token.py
@@ -1,12 +1,22 @@
-from itsdangerous import URLSafeTimedSerializer
+from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired
 from notifications_utils.formatters import url_encode_full_stops
 
 
+# currently api sends in a salt, we can stop doing that, and then remove the salt from the generate_token()
 def generate_token(payload, secret, salt="token"):
-    return url_encode_full_stops(URLSafeTimedSerializer(secret).dumps(payload, salt))
+    return url_encode_full_stops(URLSafeTimedSerializer(secret).dumps(payload, "token"))
 
 
+# After a day, all valid tokens will be signed with the salt "token" instead of DANGEROUS_SALT.
+# So we can:
+#  - stop passing the salt to check_token() in api
+#  - remove the "try / except" block below (and just return the ser.loads())
+#  - tweak the tests to not pass in the salt
 def check_token(token, secret, salt="token", max_age_seconds=60 * 60 * 24):
     ser = URLSafeTimedSerializer(secret)
-    payload = ser.loads(token, max_age=max_age_seconds, salt=salt)
-    return payload
+    try:
+        return ser.loads(token, max_age=max_age_seconds, salt="token")
+    except SignatureExpired:
+        raise
+    except BadSignature:
+        return ser.loads(token, max_age=max_age_seconds, salt=salt)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = '(notifications_utils|tests)/.*\.pyi?$'
 
 [tool.poetry]
 name = "notifications-utils"
-version = "50.3.2"
+version = "50.3.3"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_url_safe_tokens.py
+++ b/tests/test_url_safe_tokens.py
@@ -13,12 +13,11 @@ def test_works_without_salt():
     assert payload == check_token(token, "secret-key")
 
 
-def test_fails_for_incorrect_salt():
+def test_generate_uses_salt_token():
     payload = "email@something.com"
-    token = generate_token(payload, "secret-key")
+    token = generate_token(payload, "secret-key", salt="s1")
     token = urllib.parse.unquote(token)
-    with pytest.raises(BadSignature):
-        assert payload == check_token(token, "secret-key", salt="wrong-salt")
+    assert payload == check_token(token, "secret-key", salt="token")
 
 
 def test_should_return_payload_from_signed_token():

--- a/tests/test_url_safe_tokens.py
+++ b/tests/test_url_safe_tokens.py
@@ -1,8 +1,9 @@
 import urllib
 
-from itsdangerous import BadSignature, SignatureExpired
+from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 import pytest
 
+from notifications_utils.formatters import url_encode_full_stops
 from notifications_utils.url_safe_token import generate_token, check_token
 
 
@@ -18,6 +19,13 @@ def test_generate_uses_salt_token():
     token = generate_token(payload, "secret-key", salt="s1")
     token = urllib.parse.unquote(token)
     assert payload == check_token(token, "secret-key", salt="token")
+
+
+def test_check_verifies_if_generated_with_salt_parameter():
+    payload = "email@something.com"
+    token = url_encode_full_stops(URLSafeTimedSerializer("secret-key").dumps(payload, "s1"))
+    token = urllib.parse.unquote(token)
+    assert payload == check_token(token, "secret-key", salt="s1")
 
 
 def test_should_return_payload_from_signed_token():


### PR DESCRIPTION
# Summary | Résumé

This is used by api to generate tokens for invitation emails.
We want to move towards using the salt "token" here rather the the DANGEROUS_SALT that api passes in. 

Tokens are used:
- in admin to verify email addresses ([valid for 1 hour](https://github.com/cds-snc/notification-admin/blob/main/app/config.py#L74))
- in api to invite people to teams ([valid for 2 days](https://github.com/cds-snc/notification-api/blob/main/app/config.py#L219))

Idea:
- currently the DANGEROUS_SALT is being used to generate and verify tokens
- in this PR we change the code to use "token" to generate and "token" and DANGEROUS_SALT to check (ie either one will work)
- after this code has been deployed in admin / api prod for 2 days, there will be no valid tokens signed with DANGEROUS_SALT
- we can then change admin and api to not pass in the salt
- after that we can change generate / check in utils to not accept a salt

# Test instructions | Instructions pour tester la modification

Note (in the second step below): to use this branch in api (locally), change api's `pyproject.toml` to have:
```
notifications-utils = {git = "https://github.com/cds-snc/notifier-utils.git", branch = "tweak-token-code"}
```
Then in a terminal:
```
$ poetry install
```

- generate an invite link (ex: you+testinvite@cds-snc.ca)
- stop api, change to use this branch, restart api
- verify that the invite link you generated still works (basically, just click on it and verify you don't get a "Something’s wrong with this link." error)
- send another invite link and check that one too