### PR TITLE
Change token code to not have a salt argument

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = '(notifications_utils|tests)/.*\.pyi?$'
 
 [tool.poetry]
 name = "notifications-utils"
-version = "50.3.3"
+version = "51.0.0"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_url_safe_tokens.py
+++ b/tests/test_url_safe_tokens.py
@@ -1,52 +1,30 @@
 import urllib
 
-from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
+from itsdangerous import BadSignature, SignatureExpired
 import pytest
 
-from notifications_utils.formatters import url_encode_full_stops
 from notifications_utils.url_safe_token import generate_token, check_token
-
-
-def test_works_without_salt():
-    payload = "email@something.com"
-    token = generate_token(payload, "secret-key")
-    token = urllib.parse.unquote(token)
-    assert payload == check_token(token, "secret-key")
-
-
-def test_generate_uses_salt_token():
-    payload = "email@something.com"
-    token = generate_token(payload, "secret-key", salt="s1")
-    token = urllib.parse.unquote(token)
-    assert payload == check_token(token, "secret-key", salt="token")
-
-
-def test_check_verifies_if_generated_with_salt_parameter():
-    payload = "email@something.com"
-    token = url_encode_full_stops(URLSafeTimedSerializer("secret-key").dumps(payload, "s1"))
-    token = urllib.parse.unquote(token)
-    assert payload == check_token(token, "secret-key", salt="s1")
 
 
 def test_should_return_payload_from_signed_token():
     payload = "email@something.com"
-    token = generate_token(payload, "secret-key", "dangerous-salt")
+    token = generate_token(payload, "secret-key")
     token = urllib.parse.unquote(token)
-    assert payload == check_token(token, "secret-key", "dangerous-salt", 30)
+    assert payload == check_token(token, "secret-key", 30)
 
 
 def test_should_throw_exception_when_token_is_tampered_with():
     import uuid
 
-    token = generate_token(str(uuid.uuid4()), "secret-key", "dangerous-salt")
+    token = generate_token(str(uuid.uuid4()), "secret-key")
     with pytest.raises(BadSignature):
-        check_token(token + "qerqwer", "secret-key", "dangerous-salt", 30)
+        check_token(token + "qerqwer", "secret-key", 30)
 
 
 def test_return_none_when_token_is_expired():
     max_age = -1000
     payload = "some_payload"
-    token = generate_token(payload, "secret-key", "dangerous-salt")
+    token = generate_token(payload, "secret-key")
     token = urllib.parse.unquote(token)
     with pytest.raises(SignatureExpired):
-        assert check_token(token, "secret-key", "dangerous-salt", max_age) is None
+        assert check_token(token, "secret-key", max_age) is None


### PR DESCRIPTION
# Summary | Résumé

Now that https://github.com/cds-snc/notification-admin/pull/1549 and https://github.com/cds-snc/notification-api/pull/1865 have merged we are not sending a salt argument to `generate_token()` nor to `check_token()`. This PR modifies those functions to not have a salt argument anymore.

# Test instructions | Instructions pour tester la modification

Run admin and api locally, installing utils from this branch.

For all of these we just need to click on the link and verify that it goes to the appropriate Notify page without reporting that there is an error in the link.
- [ ] change your email address
- [ ] create a new account
- [ ] forget your password
- [ ] invite someone to your team
