### PR TITLE
Add `get_total_hard_bounces` to the bounce rate client

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 Flask==2.2.3
 markupsafe==2.1.2
-git+https://github.com/cds-snc/notifier-utils.git@50.3.2#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@50.3.4#egg=notifications-utils

--- a/notifications_utils/clients/redis/bounce_rate.py
+++ b/notifications_utils/clients/redis/bounce_rate.py
@@ -40,10 +40,12 @@ class RedisBounceRate:
         )
 
     def set_sliding_notifications(self, service_id: str, notification_id: str) -> None:
+        """Add a notification to the sliding total notifications sorted set in Redis."""
         current_time = _current_timestamp_s()
         self._redis_client.add_data_to_sorted_set(total_notifications_key(service_id), {notification_id: current_time})
 
     def set_sliding_hard_bounce(self, service_id: str, notification_id: str) -> None:
+        """Add a notification to the sliding hard bounce sorted set in Redis."""
         current_time = _current_timestamp_s()
         self._redis_client.add_data_to_sorted_set(hard_bounce_key(service_id), {notification_id: current_time})
 
@@ -65,19 +67,25 @@ class RedisBounceRate:
         return False
 
     def clear_bounce_rate_data(self, service_id: str) -> None:
-        """Clears all data for a service before seeding new data"""
+        """Clears all bounce rate data for a service before seeding new data"""
         self._redis_client.delete(hard_bounce_key(service_id))
         self._redis_client.delete(total_notifications_key(service_id))
 
     def get_total_hard_bounces(self, service_id: str, bounce_window=TWENTY_FOUR_HOURS_IN_SECONDS) -> int:
+        """Returns the total number of hard bounces for a service in the bounce_window"""
         now = _current_timestamp_s()
         twenty_four_hours_ago = now - bounce_window
-
-        total_hard_bounces = self._redis_client.get_length_of_sorted_set(
+        return self._redis_client.get_length_of_sorted_set(
             hard_bounce_key(service_id), min_score=twenty_four_hours_ago, max_score=now
         )
-        return total_hard_bounces
 
+    def get_total_notifications(self, service_id: str, bounce_window=TWENTY_FOUR_HOURS_IN_SECONDS) -> int:
+        """Returns the total number of email notifications a service has sent in the bounce_window"""
+        now = _current_timestamp_s()
+        twenty_four_hours_ago = now - bounce_window
+        return self._redis_client.get_length_of_sorted_set(
+            total_notifications_key(service_id), min_score=twenty_four_hours_ago, max_score=now
+        )
 
     def get_bounce_rate(self, service_id: str, bounce_window=TWENTY_FOUR_HOURS_IN_SECONDS) -> float:
         """Returns the bounce rate for a service in the last 24 hours, and deletes data older than 24 hours"""
@@ -91,9 +99,7 @@ class RedisBounceRate:
         )
 
         total_hard_bounces = self.get_total_hard_bounces(service_id, bounce_window)
-        total_notifications = self._redis_client.get_length_of_sorted_set(
-            total_notifications_key(service_id), min_score=twenty_four_hours_ago, max_score=now
-        )
+        total_notifications = self.get_total_notifications(service_id, bounce_window)
 
         if total_notifications < 1:
             return 0.0
@@ -105,12 +111,8 @@ class RedisBounceRate:
         now = _current_timestamp_s()
         twenty_four_hours_ago = now - bounce_window
 
-        total_hard_bounces = self._redis_client.get_length_of_sorted_set(
-            hard_bounce_key(service_id), min_score=twenty_four_hours_ago, max_score=now
-        )
-        total_notifications = self._redis_client.get_length_of_sorted_set(
-            total_notifications_key(service_id), min_score=twenty_four_hours_ago, max_score=now
-        )
+        total_hard_bounces = self.get_total_hard_bounces(service_id, bounce_window)
+        total_notifications = self.get_total_notifications(service_id, bounce_window)
 
         return {
             "total_notifications": total_notifications,
@@ -122,13 +124,8 @@ class RedisBounceRate:
     def check_bounce_rate_status(
         self, service_id: str, volume_threshold: int = DEFAULT_VOLUME_THRESHOLD, bounce_window=TWENTY_FOUR_HOURS_IN_SECONDS
     ):
-        now = _current_timestamp_s()
-        twenty_four_hours_ago = now - bounce_window
-        bounce_rate = self.get_bounce_rate(service_id)
-
-        total_notifications = self._redis_client.get_length_of_sorted_set(
-            total_notifications_key(service_id), min_score=twenty_four_hours_ago, max_score=now
-        )
+        bounce_rate = self.get_bounce_rate(service_id, bounce_window)
+        total_notifications = self.get_total_notifications(service_id, bounce_window)
 
         if total_notifications < volume_threshold or bounce_rate < self._warning_threshold:
             return "normal"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = '(notifications_utils|tests)/.*\.pyi?$'
 
 [tool.poetry]
 name = "notifications-utils"
-version = "50.3.3"
+version = "50.3.4"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_bounce_rate.py
+++ b/tests/test_bounce_rate.py
@@ -142,6 +142,20 @@ class TestRedisBounceRate:
             total_notifications_key(mocked_service_id), seeded_data
         )
 
+    def test_get_total_notifications(self, better_mocked_bounce_rate_client: RedisBounceRate, mocked_service_id):
+        assert better_mocked_bounce_rate_client.get_total_notifications(mocked_service_id) == 0
+        better_mocked_bounce_rate_client.set_sliding_notifications(mocked_service_id, mocked_notification_id())
+        better_mocked_bounce_rate_client.set_sliding_notifications(mocked_service_id, mocked_notification_id())
+        better_mocked_bounce_rate_client.set_sliding_notifications(mocked_service_id, mocked_notification_id())
+        assert better_mocked_bounce_rate_client.get_total_notifications(mocked_service_id) == 3
+
+    def test_get_total_hard_bounces(self, better_mocked_bounce_rate_client: RedisBounceRate, mocked_service_id):
+        assert better_mocked_bounce_rate_client.get_total_hard_bounces(mocked_service_id) == 0
+        better_mocked_bounce_rate_client.set_sliding_hard_bounce(mocked_service_id, mocked_notification_id())
+        better_mocked_bounce_rate_client.set_sliding_hard_bounce(mocked_service_id, mocked_notification_id())
+        better_mocked_bounce_rate_client.set_sliding_hard_bounce(mocked_service_id, mocked_notification_id())
+        assert better_mocked_bounce_rate_client.get_total_hard_bounces(mocked_service_id) == 3
+
     def test_seeding_started_flag(self, better_mocked_bounce_rate_client, mocked_service_id):
         assert better_mocked_bounce_rate_client.get_seeding_started(mocked_service_id) is False
         better_mocked_bounce_rate_client.set_seeding_started(mocked_service_id)

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -38,7 +38,7 @@ def test_s3upload_save_file_to_bucket_with_contenttype(mocker):
 def test_s3upload_raises_exception(app, mocker):
     mocked = mocker.patch("notifications_utils.s3.resource")
     response = {"Error": {"Code": 500}}
-    exception = botocore.exceptions.ClientError(response, "Bad exception")
+    exception = botocore.exceptions.ClientError(response, "Bad exception")  # type: ignore
     mocked.return_value.Object.return_value.put.side_effect = exception
     with pytest.raises(botocore.exceptions.ClientError):
         s3upload(filedata=contents, region=region, bucket_name=bucket, file_location="location")
@@ -72,7 +72,7 @@ def test_s3download_gets_file(mocker):
 def test_s3download_raises_on_error(mocker):
     mocked = mocker.patch("notifications_utils.s3.resource")
     mocked.return_value.Object.side_effect = botocore.exceptions.ClientError(
-        {"Error": {"Code": 404}},
+        {"Error": {"Code": 404}},  # type: ignore
         "Bad exception",
     )
 


### PR DESCRIPTION
# Summary | Résumé

This PR adds the `get_total_hard_bounces` method to our bounce rate client. This is so we can populate this number on the dashboard from Redis and will be used over in this PR: https://github.com/cds-snc/notification-admin/pull/1554

I also added `get_total_notifications` in case we need that later, and some docstrings.

# Test instructions | Instructions pour tester la modification

Tests should pass in CI.
