### PR TITLE
Add an email character limit

### DIFF
--- a/notifications_utils/__init__.py
+++ b/notifications_utils/__init__.py
@@ -1,7 +1,7 @@
 import re
 
 SMS_CHAR_COUNT_LIMIT = 612  # 153 * 4
-EMAIL_CHAR_COUNT_LIMIT = 50000  # the template that caused an incident on 2023-06-01 was 210,166 characters long
+EMAIL_CHAR_COUNT_LIMIT = 50  # the template that caused an incident on 2023-06-01 was 210,166 characters long
 
 # regexes for use in recipients.validate_email_address.
 # Valid characters taken from https://en.wikipedia.org/wiki/Email_address#Local-part

--- a/notifications_utils/__init__.py
+++ b/notifications_utils/__init__.py
@@ -1,6 +1,7 @@
 import re
 
 SMS_CHAR_COUNT_LIMIT = 612  # 153 * 4
+EMAIL_CHAR_COUNT_LIMIT = 50000  # the template that caused an incident on 2023-06-01 was 210,166 characters long
 
 # regexes for use in recipients.validate_email_address.
 # Valid characters taken from https://en.wikipedia.org/wiki/Email_address#Local-part

--- a/notifications_utils/__init__.py
+++ b/notifications_utils/__init__.py
@@ -1,7 +1,7 @@
 import re
 
 SMS_CHAR_COUNT_LIMIT = 612  # 153 * 4
-EMAIL_CHAR_COUNT_LIMIT = 50  # the template that caused an incident on 2023-06-01 was 210,166 characters long
+EMAIL_CHAR_COUNT_LIMIT = 50000  # the template that caused an incident on 2023-06-01 was 210,166 characters long
 
 # regexes for use in recipients.validate_email_address.
 # Valid characters taken from https://en.wikipedia.org/wiki/Email_address#Local-part

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -158,6 +158,8 @@ class Template:
 
 
 class SMSMessageTemplate(Template):
+    CHAR_COUNT_LIMIT = SMS_CHAR_COUNT_LIMIT
+    
     def __init__(
         self,
         template,
@@ -207,7 +209,7 @@ class SMSMessageTemplate(Template):
         return get_sms_fragment_count(self.content_count, is_unicode(content_with_placeholders))
 
     def is_message_too_long(self):
-        return self.content_count > SMS_CHAR_COUNT_LIMIT
+        return self.content_count > self.CHAR_COUNT_LIMIT
 
 
 class SMSPreviewTemplate(SMSMessageTemplate):
@@ -344,6 +346,7 @@ class HTMLEmailTemplate(WithSubjectTemplate):
     jinja_template = template_env.get_template("email/email_template.jinja2")
 
     PREHEADER_LENGTH_IN_CHARACTERS = 256
+    CHAR_COUNT_LIMIT = EMAIL_CHAR_COUNT_LIMIT
 
     def __init__(
         self,
@@ -417,7 +420,7 @@ class HTMLEmailTemplate(WithSubjectTemplate):
         return len(HTMLEmailTemplate.__str__(self))
             
     def is_message_too_long(self):
-        return self.content_count > EMAIL_CHAR_COUNT_LIMIT
+        return self.content_count > self.CHAR_COUNT_LIMIT
 
 
 class EmailPreviewTemplate(WithSubjectTemplate):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -422,7 +422,8 @@ class HTMLEmailTemplate(WithSubjectTemplate):
             # of the template counting content like "((name))" as 8 characters
             return len(self._template["content"])
         # this is the length of the template after placeholders have been replaced
-        return len(self.content)
+        plaintext_email = Take(Field(self.content, self.values, html="passthrough", markdown_lists=True))
+        return len(plaintext_email)
 
     def is_message_too_long(self):
         return self.content_count > self.CHAR_COUNT_LIMIT
@@ -521,7 +522,8 @@ class EmailPreviewTemplate(WithSubjectTemplate):
             # of the template counting content like "((name))" as 8 characters
             return len(self._template["content"])
         # this is the length of the template after placeholders have been replaced
-        return len(self.content)
+        plaintext_email = Take(Field(self.content, self.values, html="passthrough", markdown_lists=True))
+        return len(plaintext_email)
 
     def is_message_too_long(self):
         return self.content_count > self.CHAR_COUNT_LIMIT

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -159,7 +159,7 @@ class Template:
 
 class SMSMessageTemplate(Template):
     CHAR_COUNT_LIMIT = SMS_CHAR_COUNT_LIMIT
-    
+
     def __init__(
         self,
         template,
@@ -417,13 +417,21 @@ class HTMLEmailTemplate(WithSubjectTemplate):
 
     @property
     def content_count(self):
-        return len(HTMLEmailTemplate.__str__(self))
-            
+        if self.missing_data:
+            # variables have not yet been populated, so just take the length of
+            # of the template counting content like "((name))" as 8 characters
+            return len(self._template["content"])
+        # this is the length of the template after placeholders have been replaced
+        return len(self.content)
+
     def is_message_too_long(self):
         return self.content_count > self.CHAR_COUNT_LIMIT
 
 
 class EmailPreviewTemplate(WithSubjectTemplate):
+
+    CHAR_COUNT_LIMIT = EMAIL_CHAR_COUNT_LIMIT
+
     def __init__(
         self,
         template,
@@ -508,10 +516,16 @@ class EmailPreviewTemplate(WithSubjectTemplate):
 
     @property
     def content_count(self):
-        return len(EmailPreviewTemplate.__str__(self))
-            
+        if self.missing_data:
+            # variables have not yet been populated, so just take the length of
+            # of the template counting content like "((name))" as 8 characters
+            return len(self._template["content"])
+        # this is the length of the template after placeholders have been replaced
+        return len(self.content)
+
     def is_message_too_long(self):
-        return self.content_count > EMAIL_CHAR_COUNT_LIMIT
+        return self.content_count > self.CHAR_COUNT_LIMIT
+
 
 class LetterPreviewTemplate(WithSubjectTemplate):
 

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -411,9 +411,13 @@ class HTMLEmailTemplate(WithSubjectTemplate):
                 "brand_name": self.brand_name,
             }
         )
-        
+
+    @property
+    def content_count(self):
+        return len(HTMLEmailTemplate.__str__(self))
+            
     def is_message_too_long(self):
-        return len(self.content) > EMAIL_CHAR_COUNT_LIMIT
+        return self.content_count > EMAIL_CHAR_COUNT_LIMIT
 
 
 class EmailPreviewTemplate(WithSubjectTemplate):
@@ -499,6 +503,12 @@ class EmailPreviewTemplate(WithSubjectTemplate):
             .then(normalise_whitespace)
         )
 
+    @property
+    def content_count(self):
+        return len(EmailPreviewTemplate.__str__(self))
+            
+    def is_message_too_long(self):
+        return self.content_count > EMAIL_CHAR_COUNT_LIMIT
 
 class LetterPreviewTemplate(WithSubjectTemplate):
 

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -7,7 +7,7 @@ from jinja2 import Environment, FileSystemLoader
 from flask import Markup
 from html import unescape
 
-from notifications_utils import SMS_CHAR_COUNT_LIMIT
+from notifications_utils import EMAIL_CHAR_COUNT_LIMIT, SMS_CHAR_COUNT_LIMIT
 from notifications_utils.columns import Columns
 from notifications_utils.field import Field
 from notifications_utils.formatters import (
@@ -411,6 +411,9 @@ class HTMLEmailTemplate(WithSubjectTemplate):
                 "brand_name": self.brand_name,
             }
         )
+        
+    def is_message_too_long(self):
+        return len(self.content) > EMAIL_CHAR_COUNT_LIMIT
 
 
 class EmailPreviewTemplate(WithSubjectTemplate):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = '(notifications_utils|tests)/.*\.pyi?$'
 
 [tool.poetry]
 name = "notifications-utils"
-version = "51.0.1"
+version = "51.0.2"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1928,8 +1928,8 @@ def test_sms_message_too_long(template_class):
     ],
 )
 def test_email_message_too_long(template_class):
-    body = ("b" * 40) + "((foo))"
-    template = template_class({"content": body, "subject": "abc"}, values={"foo": "c" * 11})
+    body = ("b" * 40000) + "((foo))"
+    template = template_class({"content": body, "subject": "abc"}, values={"foo": "c" * 10001})
     assert template.is_message_too_long() is True
 
 
@@ -1942,7 +1942,7 @@ def test_email_message_too_long(template_class):
 )
 def test_email_message_not_too_long(template_class):
     body = ("b" * 40000) + "((foo))"
-    template = template_class({"content": body, "subject": "abc"}, values={"foo": "c" * 9999})
+    template = template_class({"content": body, "subject": "abc"}, values={"foo": "c" * 10000})
     assert template.is_message_too_long() is False
 
 

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1914,9 +1914,23 @@ def test_lists_in_combination_with_other_elements_in_letters(markdown, expected)
         SMSPreviewTemplate,
     ],
 )
-def test_message_too_long(template_class):
+def test_sms_message_too_long(template_class):
     body = ("b" * 400) + "((foo))"
     template = template_class({"content": body}, prefix="a" * 100, values={"foo": "c" * 200})
+    assert template.is_message_too_long() is True
+    
+
+@pytest.mark.parametrize(
+    "template_class",
+    [
+        HTMLEmailTemplate,
+        EmailPreviewTemplate,
+    ],
+)
+def test_email_message_too_long(template_class):
+    body = ("b" * 40001) + "((foo))"
+    template = template_class({"content": body, "subject": "abc"}, values={"foo": "c" * 10001})
+    # template = HTMLEmailTemplate({"content": body, "subject": "abc"}, values={"foo": "c" * 10001})
     assert template.is_message_too_long() is True
 
 

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1918,7 +1918,7 @@ def test_sms_message_too_long(template_class):
     body = ("b" * 400) + "((foo))"
     template = template_class({"content": body}, prefix="a" * 100, values={"foo": "c" * 200})
     assert template.is_message_too_long() is True
-    
+
 
 @pytest.mark.parametrize(
     "template_class",
@@ -1928,10 +1928,22 @@ def test_sms_message_too_long(template_class):
     ],
 )
 def test_email_message_too_long(template_class):
-    body = ("b" * 40001) + "((foo))"
+    body = ("b" * 40000) + "((foo))"
     template = template_class({"content": body, "subject": "abc"}, values={"foo": "c" * 10001})
-    # template = HTMLEmailTemplate({"content": body, "subject": "abc"}, values={"foo": "c" * 10001})
     assert template.is_message_too_long() is True
+
+
+@pytest.mark.parametrize(
+    "template_class",
+    [
+        HTMLEmailTemplate,
+        EmailPreviewTemplate,
+    ],
+)
+def test_email_message_not_too_long(template_class):
+    body = ("b" * 40000) + "((foo))"
+    template = template_class({"content": body, "subject": "abc"}, values={"foo": "c" * 9999})
+    assert template.is_message_too_long() is False
 
 
 @pytest.mark.parametrize(

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1928,8 +1928,8 @@ def test_sms_message_too_long(template_class):
     ],
 )
 def test_email_message_too_long(template_class):
-    body = ("b" * 40000) + "((foo))"
-    template = template_class({"content": body, "subject": "abc"}, values={"foo": "c" * 10001})
+    body = ("b" * 40) + "((foo))"
+    template = template_class({"content": body, "subject": "abc"}, values={"foo": "c" * 11})
     assert template.is_message_too_long() is True
 
 


### PR DESCRIPTION
# Summary | Résumé

This PR:
- introduces an email character limit of 50k to prevent extremely long emails from causing problems
- implements the limit both for templates with variables unpopulated (for use at template creation time) and for templates with variables populated (for use at send time)
-  adds a `CHAR_COUNT_LIMIT` property to `SMSMessageTemplate`, `EmailPreviewTemplate`, and `HTMLEmailTemplate` to reduce some of the `import` statements and extra logic we will need to implement in notification-api
 - does not introduce any breaking changes
 
# Test instructions | Instructions pour tester la modification

CI tests should pass. Manual testing will be easier when https://github.com/cds-snc/notification-api/pull/1896 is ready for review. 