### PR TITLE
Bump to a new version 51.0.4

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 Flask==2.2.3
 markupsafe==2.1.3
-git+https://github.com/cds-snc/notifier-utils.git@51.0.3#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@51.0.4#egg=notifications-utils

--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 Flask==2.2.3
 markupsafe==2.1.3
-git+https://github.com/cds-snc/notifier-utils.git@51.0.2#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@51.0.3#egg=notifications-utils

--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 Flask==2.2.3
 markupsafe==2.1.3
-git+https://github.com/cds-snc/notifier-utils.git@50.3.4#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@51.0.2#egg=notifications-utils

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = '(notifications_utils|tests)/.*\.pyi?$'
 
 [tool.poetry]
 name = "notifications-utils"
-version = "51.0.2"
+version = "51.0.3"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = '(notifications_utils|tests)/.*\.pyi?$'
 
 [tool.poetry]
 name = "notifications-utils"
-version = "51.0.3"
+version = "51.0.4"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"


### PR DESCRIPTION
# Summary | Résumé

I forgot to increment the waffles requirement when I tagged version 51.0.2. That is causing an error in the notification-api CI pipeline. This PR should fix that.

# Test instructions | Instructions pour tester la modification

Tests should pass.