### PR TITLE
bump utils version to 52.0.6

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 Flask==2.3.2
 markupsafe==2.1.3
-git+https://github.com/cds-snc/notifier-utils.git@52.0.5#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@52.0.6#egg=notifications-utils

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = '(notifications_utils|tests)/.*\.pyi?$'
 
 [tool.poetry]
 name = "notifications-utils"
-version = "52.0.5"
+version = "52.0.6"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"


### PR DESCRIPTION
# Summary | Résumé
Bumping version to include [dependency upgrades](https://github.com/cds-snc/notification-utils/pull/215) needed to completed the work on [1134](https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1134)