### PR TITLE
Feat/add system status utilities

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.3
-git+https://github.com/cds-snc/notifier-utils.git@52.0.16#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@52.0.17#egg=notifications-utils

--- a/notifications_utils/system_status.py
+++ b/notifications_utils/system_status.py
@@ -105,7 +105,6 @@ def determine_site_status(url, threshold):
         api_response_time = check_response_time(url)
         site_status = "up" if api_response_time <= threshold else "degraded"
 
-    # handle all expected exceptions
     except requests.exceptions.ConnectionError as e:
         logging.error("utils/system_status: determine_site_status({}): Error connecting to url: {}".format(url, e))
         site_status = "down"

--- a/notifications_utils/system_status.py
+++ b/notifications_utils/system_status.py
@@ -1,0 +1,121 @@
+import logging
+import requests
+
+
+TEMPLATES = {
+    "email": {
+        "low": "73079cb9-c169-44ea-8cf4-8d397711cc9d",
+        "medium": "c75c4539-3014-4c4c-96b5-94d326758a74",
+        "high": "276da251-3103-49f3-9054-cbf6b5d74411",
+    },
+    "sms": {
+        "low": "ab3a603b-d602-46ea-8c83-e05cb280b950",
+        "medium": "a48b54ce-40f6-4e4a-abe8-1e2fa389455b",
+        "high": "4969a9e9-ddfd-476e-8b93-6231e6f1be4a",
+    },
+}
+
+THRESHOLDS = {
+    "email-low": 3 * 60 * 60 * 1000,  # 3 hours
+    "email-medium": 45 * 60 * 1000,  # 45 minutes
+    "email-high": 60 * 1000,  # 60 seconds
+    "sms-low": 3 * 60 * 60 * 1000,  # 3 hours
+    "sms-medium": 45 * 60 * 1000,  # 45 minutes
+    "sms-high": 60 * 1000,  # 60 seconds
+    "api": 400,  # 400ms
+    "admin": 400,  # 400ms
+}
+
+
+def determine_notification_status(dbresults):  # noqa: C901
+    # default all to down
+    email_status_low = "down"
+    email_status_medium = "down"
+    email_status_high = "down"
+    sms_status_low = "down"
+    sms_status_medium = "down"
+    sms_status_high = "down"
+
+    for row in dbresults:
+        if str(row[0]) == TEMPLATES["email"]["low"]:
+            email_low_response_time = row[1]
+            if email_low_response_time <= THRESHOLDS["email-low"]:
+                email_status_low = "up"
+            else:
+                email_status_low = "degraded"
+
+        elif str(row[0]) == TEMPLATES["email"]["medium"]:
+            email_medium_response_time = row[1]
+            if email_medium_response_time <= THRESHOLDS["email-medium"]:
+                email_status_medium = "up"
+            else:
+                email_status_medium = "degraded"
+
+        elif str(row[0]) == TEMPLATES["email"]["high"]:
+            email_high_response_time = row[1]
+            if email_high_response_time <= THRESHOLDS["email-high"]:
+                email_status_high = "up"
+            else:
+                email_status_high = "degraded"
+
+        elif str(row[0]) == TEMPLATES["sms"]["low"]:
+            sms_low_response_time = row[1]
+            if sms_low_response_time <= THRESHOLDS["sms-low"]:
+                sms_status_low = "up"
+            else:
+                sms_status_low = "degraded"
+
+        elif str(row[0]) == TEMPLATES["sms"]["medium"]:
+            sms_medium_response_time = row[1]
+            if sms_medium_response_time <= THRESHOLDS["sms-medium"]:
+                sms_status_medium = "up"
+            else:
+                sms_status_medium = "degraded"
+
+        elif str(row[0]) == TEMPLATES["sms"]["high"]:
+            sms_high_response_time = row[1]
+            if sms_high_response_time <= THRESHOLDS["sms-high"]:
+                sms_status_high = "up"
+            else:
+                sms_status_high = "degraded"
+
+    # set overall email_status based on if one of email_status_low, email_status_medium, email_status_high is down,
+    # then email_status is down, if one is degraded, then email_status is degraded, otherwise email_status is up
+    if email_status_low == "down" or email_status_medium == "down" or email_status_high == "down":
+        email_status = "down"
+    elif email_status_low == "degraded" or email_status_medium == "degraded" or email_status_high == "degraded":
+        email_status = "degraded"
+    else:
+        email_status = "up"
+
+    # set overall sms_status based on if one of sms_status_low, sms_status_medium, sms_status_high is down,
+    # then sms_status is down, if one is degraded, then sms_status is degraded, otherwise sms_status is up
+    if sms_status_low == "down" or sms_status_medium == "down" or sms_status_high == "down":
+        sms_status = "down"
+    elif sms_status_low == "degraded" or sms_status_medium == "degraded" or sms_status_high == "degraded":
+        sms_status = "degraded"
+    else:
+        sms_status = "up"
+
+    return (email_status, sms_status)
+
+
+def determine_site_status(url, threshold):
+    try:
+        api_response_time = check_response_time(url)
+        site_status = "up" if api_response_time <= threshold else "degraded"
+
+    # handle all expected exceptions
+    except requests.exceptions.ConnectionError as e:
+        logging.error("utils/system_status: determine_site_status({}): Error connecting to url: {}".format(url, e))
+        site_status = "down"
+    except Exception as e:
+        logging.error("utils/system_status: determine_site_status({}): unknown error: {}".format(url, e))
+        site_status = "down"
+
+    return site_status
+
+
+def check_response_time(url):
+    response = requests.get(url)
+    return response.elapsed.total_seconds() * 1000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = '(notifications_utils|tests)/.*\.pyi?$'
 
 [tool.poetry]
 name = "notifications-utils"
-version = "52.0.16"
+version = "52.0.17"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -448,7 +448,11 @@ def test_get_recipient_respects_order(file_contents, template_type, placeholders
     recipients = RecipientCSV(file_contents, template_type=template_type, placeholders=placeholders)
 
     for row, email in expected_recipients:
-        assert (recipients[row].index, recipients[row].recipient, recipients[row].personalisation,) == (
+        assert (
+            recipients[row].index,
+            recipients[row].recipient,
+            recipients[row].personalisation,
+        ) == (
             row,
             email,
             expected_personalisation[row],

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -448,11 +448,7 @@ def test_get_recipient_respects_order(file_contents, template_type, placeholders
     recipients = RecipientCSV(file_contents, template_type=template_type, placeholders=placeholders)
 
     for row, email in expected_recipients:
-        assert (
-            recipients[row].index,
-            recipients[row].recipient,
-            recipients[row].personalisation,
-        ) == (
+        assert (recipients[row].index, recipients[row].recipient, recipients[row].personalisation,) == (
             row,
             email,
             expected_personalisation[row],

--- a/tests/test_system_status.py
+++ b/tests/test_system_status.py
@@ -1,0 +1,118 @@
+import pytest
+import requests
+from notifications_utils.system_status import determine_site_status, determine_notification_status, THRESHOLDS
+
+
+@pytest.mark.parametrize("site, threshold", [("http://site-1.example.com", 400)])
+@pytest.mark.parametrize("response_time, expected_status", [(100, "up"), (500, "degraded")])
+def test_determine_site_status(mocker, site, threshold, response_time, expected_status):
+    # mock the call to check_response_time()
+    mocker.patch("notifications_utils.system_status.check_response_time", return_value=response_time)
+
+    result = determine_site_status(site, threshold)
+
+    assert result == expected_status
+
+
+def test_determine_site_status_down(mocker):
+    mocker.patch("notifications_utils.system_status.check_response_time", side_effect=requests.exceptions.ConnectionError)
+    result = determine_site_status("http://site-1.example.com", 400)
+
+    assert result == "down"
+
+
+@pytest.mark.parametrize(
+    "email_low, email_medium, email_high, expected_result",
+    [
+        (THRESHOLDS["email-low"], THRESHOLDS["email-medium"], THRESHOLDS["email-high"], "up"),
+        (THRESHOLDS["email-low"], THRESHOLDS["email-medium"], THRESHOLDS["email-high"] + 1, "degraded"),
+        (THRESHOLDS["email-low"], THRESHOLDS["email-medium"], -1, "down"),
+        (THRESHOLDS["email-low"], THRESHOLDS["email-medium"] + 1, THRESHOLDS["email-high"], "degraded"),
+        (THRESHOLDS["email-low"], THRESHOLDS["email-medium"] + 1, THRESHOLDS["email-high"] + 1, "degraded"),
+        (THRESHOLDS["email-low"], THRESHOLDS["email-medium"] + 1, -1, "down"),
+        (THRESHOLDS["email-low"], -1, THRESHOLDS["email-high"], "down"),
+        (THRESHOLDS["email-low"], -1, THRESHOLDS["email-high"] + 1, "down"),
+        (THRESHOLDS["email-low"], -1, -1, "down"),
+        (THRESHOLDS["email-low"] + 1, THRESHOLDS["email-medium"], THRESHOLDS["email-high"], "degraded"),
+        (THRESHOLDS["email-low"] + 1, THRESHOLDS["email-medium"], THRESHOLDS["email-high"] + 1, "degraded"),
+        (THRESHOLDS["email-low"] + 1, THRESHOLDS["email-medium"], -1, "down"),
+        (THRESHOLDS["email-low"] + 1, THRESHOLDS["email-medium"] + 1, THRESHOLDS["email-high"], "degraded"),
+        (THRESHOLDS["email-low"] + 1, THRESHOLDS["email-medium"] + 1, THRESHOLDS["email-high"] + 1, "degraded"),
+        (THRESHOLDS["email-low"] + 1, THRESHOLDS["email-medium"] + 1, -1, "down"),
+        (THRESHOLDS["email-low"] + 1, -1, THRESHOLDS["email-high"], "down"),
+        (THRESHOLDS["email-low"] + 1, -1, THRESHOLDS["email-high"] + 1, "down"),
+        (THRESHOLDS["email-low"] + 1, -1, -1, "down"),
+        (-1, THRESHOLDS["email-medium"], THRESHOLDS["email-high"], "down"),
+        (-1, THRESHOLDS["email-medium"], THRESHOLDS["email-high"] + 1, "down"),
+        (-1, THRESHOLDS["email-medium"], -1, "down"),
+        (-1, THRESHOLDS["email-medium"] + 1, THRESHOLDS["email-high"], "down"),
+        (-1, THRESHOLDS["email-medium"] + 1, THRESHOLDS["email-high"] + 1, "down"),
+        (-1, THRESHOLDS["email-medium"] + 1, -1, "down"),
+        (-1, -1, THRESHOLDS["email-high"], "down"),
+        (-1, -1, THRESHOLDS["email-high"] + 1, "down"),
+        (-1, -1, -1, "down"),
+    ],
+)
+def test_determine_notification_status_for_email(mocker, email_low, email_medium, email_high, expected_result):
+
+    notifications_data = [
+        ["73079cb9-c169-44ea-8cf4-8d397711cc9d", email_low]
+        if email_low != -1
+        else [
+            "dummy-data",
+            0,
+        ],  # this just omits a row with the particular id in the case of -1, since there would be no db records
+        ["c75c4539-3014-4c4c-96b5-94d326758a74", email_medium] if email_medium != -1 else ["dummy-data", 0],
+        ["276da251-3103-49f3-9054-cbf6b5d74411", email_high] if email_high != -1 else ["dummy-data", 0],
+        ["ab3a603b-d602-46ea-8c83-e05cb280b950", 1],  # SMS
+        ["a48b54ce-40f6-4e4a-abe8-1e2fa389455b", 1],  # SMS    # med sms
+        ["4969a9e9-ddfd-476e-8b93-6231e6f1be4a", 1],
+    ]
+
+    assert determine_notification_status(notifications_data) == (expected_result, "up")
+
+
+@pytest.mark.parametrize(
+    "sms_low, sms_medium, sms_high, expected_result",
+    [
+        (THRESHOLDS["sms-low"], THRESHOLDS["sms-medium"], THRESHOLDS["sms-high"], "up"),
+        (THRESHOLDS["sms-low"], THRESHOLDS["sms-medium"], THRESHOLDS["sms-high"] + 1, "degraded"),
+        (THRESHOLDS["sms-low"], THRESHOLDS["sms-medium"], -1, "down"),
+        (THRESHOLDS["sms-low"], THRESHOLDS["sms-medium"] + 1, THRESHOLDS["sms-high"], "degraded"),
+        (THRESHOLDS["sms-low"], THRESHOLDS["sms-medium"] + 1, THRESHOLDS["sms-high"] + 1, "degraded"),
+        (THRESHOLDS["sms-low"], THRESHOLDS["sms-medium"] + 1, -1, "down"),
+        (THRESHOLDS["sms-low"], -1, THRESHOLDS["sms-high"], "down"),
+        (THRESHOLDS["sms-low"], -1, THRESHOLDS["sms-high"] + 1, "down"),
+        (THRESHOLDS["sms-low"], -1, -1, "down"),
+        (THRESHOLDS["sms-low"] + 1, THRESHOLDS["sms-medium"], THRESHOLDS["sms-high"], "degraded"),
+        (THRESHOLDS["sms-low"] + 1, THRESHOLDS["sms-medium"], THRESHOLDS["sms-high"] + 1, "degraded"),
+        (THRESHOLDS["sms-low"] + 1, THRESHOLDS["sms-medium"], -1, "down"),
+        (THRESHOLDS["sms-low"] + 1, THRESHOLDS["sms-medium"] + 1, THRESHOLDS["sms-high"], "degraded"),
+        (THRESHOLDS["sms-low"] + 1, THRESHOLDS["sms-medium"] + 1, THRESHOLDS["sms-high"] + 1, "degraded"),
+        (THRESHOLDS["sms-low"] + 1, THRESHOLDS["sms-medium"] + 1, -1, "down"),
+        (THRESHOLDS["sms-low"] + 1, -1, THRESHOLDS["sms-high"], "down"),
+        (THRESHOLDS["sms-low"] + 1, -1, THRESHOLDS["sms-high"] + 1, "down"),
+        (THRESHOLDS["sms-low"] + 1, -1, -1, "down"),
+        (-1, THRESHOLDS["sms-medium"], THRESHOLDS["sms-high"], "down"),
+        (-1, THRESHOLDS["sms-medium"], THRESHOLDS["sms-high"] + 1, "down"),
+        (-1, THRESHOLDS["sms-medium"], -1, "down"),
+        (-1, THRESHOLDS["sms-medium"] + 1, THRESHOLDS["sms-high"], "down"),
+        (-1, THRESHOLDS["sms-medium"] + 1, THRESHOLDS["sms-high"] + 1, "down"),
+        (-1, THRESHOLDS["sms-medium"] + 1, -1, "down"),
+        (-1, -1, THRESHOLDS["sms-high"], "down"),
+        (-1, -1, THRESHOLDS["sms-high"] + 1, "down"),
+        (-1, -1, -1, "down"),
+    ],
+)
+def test_determine_notification_status_for_sms(mocker, sms_low, sms_medium, sms_high, expected_result):
+
+    notifications_data = [
+        ["73079cb9-c169-44ea-8cf4-8d397711cc9d", 1],
+        ["c75c4539-3014-4c4c-96b5-94d326758a74", 1],
+        ["276da251-3103-49f3-9054-cbf6b5d74411", 1],
+        ["ab3a603b-d602-46ea-8c83-e05cb280b950", sms_low] if sms_low != -1 else ["dummy-data", 0],
+        ["a48b54ce-40f6-4e4a-abe8-1e2fa389455b", sms_medium] if sms_medium != -1 else ["dummy-data", 0],
+        ["4969a9e9-ddfd-476e-8b93-6231e6f1be4a", sms_high] if sms_high != -1 else ["dummy-data", 0],
+    ]
+
+    assert determine_notification_status(notifications_data) == ("up", expected_result)

--- a/tests/test_system_status.py
+++ b/tests/test_system_status.py
@@ -54,7 +54,6 @@ def test_determine_site_status_down(mocker):
     ],
 )
 def test_determine_notification_status_for_email(mocker, email_low, email_medium, email_high, expected_result):
-
     notifications_data = [
         ["73079cb9-c169-44ea-8cf4-8d397711cc9d", email_low]
         if email_low != -1
@@ -105,7 +104,6 @@ def test_determine_notification_status_for_email(mocker, email_low, email_medium
     ],
 )
 def test_determine_notification_status_for_sms(mocker, sms_low, sms_medium, sms_high, expected_result):
-
     notifications_data = [
         ["73079cb9-c169-44ea-8cf4-8d397711cc9d", 1],
         ["c75c4539-3014-4c4c-96b5-94d326758a74", 1],


### PR DESCRIPTION
# Summary | Résumé

This PR adds the utility functions to determine component and site statuses for the system status page.

See the [ADR on system status](https://github.com/cds-snc/notification-adr/blob/main/records/2023-11-24.system-status.md) for more details on how this works.