### PR TITLE
Add decrby to redis_client

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.4
-git+https://github.com/cds-snc/notifier-utils.git@52.1.1#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@52.1.2#egg=notifications-utils

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -203,6 +203,16 @@ class RedisClient:
             except Exception as e:
                 self.__handle_exception(e, raise_exception, "incrby", key)
 
+
+    def decrby(self, key, by, raise_exception=False,):
+        key = prepare_value(key)
+        if self.active:
+            try:
+                return self.redis_store.decrby(key, by)
+            except Exception as e:
+                self.__handle_exception(e, raise_exception, "decrby", key)
+
+
     def get(self, key, raise_exception=False):
         key = prepare_value(key)
         if self.active:

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -216,6 +216,8 @@ class RedisClient:
             except Exception as e:
                 self.__handle_exception(e, raise_exception, "decrby", key)
 
+        return None
+
     def get(self, key, raise_exception=False):
         key = prepare_value(key)
         if self.active:

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -203,15 +203,18 @@ class RedisClient:
             except Exception as e:
                 self.__handle_exception(e, raise_exception, "incrby", key)
 
-
-    def decrby(self, key, by, raise_exception=False,):
+    def decrby(
+        self,
+        key,
+        by,
+        raise_exception=False,
+    ):
         key = prepare_value(key)
         if self.active:
             try:
                 return self.redis_store.decrby(key, by)
             except Exception as e:
                 self.__handle_exception(e, raise_exception, "decrby", key)
-
 
     def get(self, key, raise_exception=False):
         key = prepare_value(key)

--- a/notifications_utils/decorators.py
+++ b/notifications_utils/decorators.py
@@ -1,0 +1,11 @@
+from flask import current_app
+from functools import wraps
+
+def requires_feature(flag):
+    def decorator_feature_flag(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            if current_app.config[flag]:
+                return func(*args, **kwargs)
+        return wrapper
+    return decorator_feature_flag

--- a/notifications_utils/decorators.py
+++ b/notifications_utils/decorators.py
@@ -8,6 +8,7 @@ def requires_feature(flag):
         def wrapper(*args, **kwargs):
             if current_app.config[flag]:
                 return func(*args, **kwargs)
+            return None
 
         return wrapper
 

--- a/notifications_utils/decorators.py
+++ b/notifications_utils/decorators.py
@@ -1,11 +1,14 @@
 from flask import current_app
 from functools import wraps
 
+
 def requires_feature(flag):
     def decorator_feature_flag(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
             if current_app.config[flag]:
                 return func(*args, **kwargs)
+
         return wrapper
+
     return decorator_feature_flag

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = '(notifications_utils|tests)/.*\.pyi?$'
 
 [tool.poetry]
 name = "notifications-utils"
-version = "52.1.1"
+version = "52.1.2"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,18 +1,18 @@
-import pytest
-from flask import current_app
 from notifications_utils.decorators import requires_feature
-from unittest import mock
 
-@requires_feature('FEATURE_FLAG')
+
+@requires_feature("FEATURE_FLAG")
 def decorated_function():
     return "Feature enabled"
 
+
 def test_requires_feature_enabled(mocker, app):
-    app.config['FEATURE_FLAG'] = True
+    app.config["FEATURE_FLAG"] = True
     result = decorated_function()
     assert result == "Feature enabled"
 
+
 def test_requires_feature_disabled(mocker, app):
-    app.config['FEATURE_FLAG'] = False
+    app.config["FEATURE_FLAG"] = False
     result = decorated_function()
     assert result is None

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,18 @@
+import pytest
+from flask import current_app
+from notifications_utils.decorators import requires_feature
+from unittest import mock
+
+@requires_feature('FEATURE_FLAG')
+def decorated_function():
+    return "Feature enabled"
+
+def test_requires_feature_enabled(mocker, app):
+    app.config['FEATURE_FLAG'] = True
+    result = decorated_function()
+    assert result == "Feature enabled"
+
+def test_requires_feature_disabled(mocker, app):
+    app.config['FEATURE_FLAG'] = False
+    result = decorated_function()
+    assert result is None

--- a/tests/test_redis_client.py
+++ b/tests/test_redis_client.py
@@ -63,6 +63,7 @@ def test_should_not_raise_exception_if_raise_set_to_false(app, caplog, mocker):
     redis_client.redis_store.get = Mock(side_effect=Exception())
     redis_client.redis_store.set = Mock(side_effect=Exception())
     redis_client.redis_store.incr = Mock(side_effect=Exception())
+    redis_client.redis_store.decrby = Mock(side_effect=Exception())
     redis_client.redis_store.pipeline = Mock(side_effect=Exception())
     redis_client.redis_store.expire = Mock(side_effect=Exception())
     redis_client.redis_store.delete = Mock(side_effect=Exception())
@@ -70,6 +71,7 @@ def test_should_not_raise_exception_if_raise_set_to_false(app, caplog, mocker):
     assert redis_client.set("set_key", "set_value") is None
     assert redis_client.incr("incr_key") is None
     assert redis_client.incrby("incrby_key", by=1) is None
+    assert redis_client.decrby("decrby_key", by=1) is None
     assert redis_client.exceeded_rate_limit("rate_limit_key", 100, 100) is False
     assert redis_client.expire("expire_key", 100) is None
     assert redis_client.delete("delete_key") is None
@@ -79,6 +81,7 @@ def test_should_not_raise_exception_if_raise_set_to_false(app, caplog, mocker):
         call.exception("Redis error performing set on set_key"),
         call.exception("Redis error performing incr on incr_key"),
         call.exception("Redis error performing incrby on incrby_key"),
+        call.exception("Redis error performing decrby on decrby_key"),
         call.exception("Redis error performing rate-limit-pipeline on rate_limit_key"),
         call.exception("Redis error performing expire on expire_key"),
         call.exception("Redis error performing delete on delete_key"),
@@ -109,6 +112,8 @@ def test_should_raise_exception_if_raise_set_to_true(app):
     with pytest.raises(Exception) as e:
         redis_client.incrby("test", by=1, raise_exception=True)
     assert str(e.value) == "incrby failed"
+    with pytest.raises(Exception) as e:
+        redis_client.decrby("test", by=1, raise_exception=True)
     with pytest.raises(Exception) as e:
         redis_client.exceeded_rate_limit("test", 100, 200, raise_exception=True)
     assert str(e.value) == "pipeline failed"


### PR DESCRIPTION
# Summary | Résumé
- Added a `decrby` method to the `redis_client`
- Added a simple decorator for functions that need to be behind a feature flag

[This API PR](https://github.com/cds-snc/notification-api/pull/2112) depends on these changes.
