### PR TITLE
Validate variables in CSV do not exceed daily limit

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.4
-git+https://github.com/cds-snc/notifier-utils.git@52.1.5#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@52.1.6#egg=notifications-utils

--- a/notifications_utils/columns.py
+++ b/notifications_utils/columns.py
@@ -132,7 +132,6 @@ class Row(Columns):
 
 class Cell:
     missing_field_error = "Missing"
-    message_too_long = "Length"
 
     def __init__(self, key=None, value=None, error_fn=None, placeholders=None, template_content_length=None):
         self.data = value
@@ -153,7 +152,3 @@ class Cell:
     @property
     def recipient_error(self):
         return self.error not in {None, self.missing_field_error}
-
-    @property
-    def content_length_error(self):
-        return self.error not in {None, self.message_too_long}

--- a/notifications_utils/columns.py
+++ b/notifications_utils/columns.py
@@ -63,7 +63,12 @@ class Row(Columns):
             template.values = row_dict
             self.message_too_long = template.is_message_too_long()
 
-        super().__init__(OrderedDict((key, Cell(key, value, error_fn, self.placeholders, len(template.content))) for key, value in row_dict.items()))
+        super().__init__(
+            OrderedDict(
+                (key, Cell(key, value, error_fn, self.placeholders, len(template.content) if template else None))
+                for key, value in row_dict.items()
+            )
+        )
 
     def __getitem__(self, key):
         return super().__getitem__(key) or Cell()

--- a/notifications_utils/columns.py
+++ b/notifications_utils/columns.py
@@ -96,13 +96,6 @@ class Row(Columns):
         return False
 
     @property
-    def has_message_too_long(self) -> bool:
-        for column in self.placeholders:
-            if self.get(key=column).content_length_error is True:
-                return True
-        return False
-
-    @property
     def has_missing_data(self):
         return any(cell.error == Cell.missing_field_error for cell in self.values())
 

--- a/notifications_utils/columns.py
+++ b/notifications_utils/columns.py
@@ -63,7 +63,7 @@ class Row(Columns):
             template.values = row_dict
             self.message_too_long = template.is_message_too_long()
 
-        super().__init__(OrderedDict((key, Cell(key, value, error_fn, self.placeholders)) for key, value in row_dict.items()))
+        super().__init__(OrderedDict((key, Cell(key, value, error_fn, self.placeholders, len(template.content))) for key, value in row_dict.items()))
 
     def __getitem__(self, key):
         return super().__getitem__(key) or Cell()
@@ -87,6 +87,13 @@ class Row(Columns):
         """
         for column in self.recipient_column_hearders_lang_check:
             if self.get(column).recipient_error is True:
+                return True
+        return False
+
+    @property
+    def has_message_too_long(self) -> bool:
+        for column in self.placeholders:
+            if self.get(key=column).content_length_error is True:
                 return True
         return False
 
@@ -120,8 +127,9 @@ class Row(Columns):
 
 class Cell:
     missing_field_error = "Missing"
+    message_too_long = "Length"
 
-    def __init__(self, key=None, value=None, error_fn=None, placeholders=None):
+    def __init__(self, key=None, value=None, error_fn=None, placeholders=None, template_content_length=None):
         self.data = value
         self.error = error_fn(key, value) if error_fn else None
         self.ignore = Columns.make_key(key) not in (placeholders or [])
@@ -140,3 +148,7 @@ class Cell:
     @property
     def recipient_error(self):
         return self.error not in {None, self.missing_field_error}
+
+    @property
+    def content_length_error(self):
+        return self.error not in {None, self.message_too_long}

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -291,7 +291,7 @@ class RecipientCSV:
                         if variable:
                             variable_length += sum(1 if char in SanitiseSMS.ALLOWED_CHARACTERS else 2 for char in str(variable))
                     total_length = variable_length + (len(self.template.content) if self.template else 0)
-                    if total_length > 612:
+                    if total_length > SMS_CHAR_COUNT_LIMIT:
                         rows_too_long.append(row)
         return (row for row in rows_too_long)
 

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -282,18 +282,16 @@ class RecipientCSV:
         Checks if the length of all variable, plus the length of the template content,
         exceeds the SMS limit of 612 characters. Counts non-GSM characters as 2.
         """
-        rows_too_long = []
         if self.rows_as_list:
             for row in self.rows_as_list:
-                if row.personalisation and self.template and self.template.placeholders:
+                if row.personalisation and self.template:
                     variable_length = 0
                     for variable in row.personalisation.as_dict_with_keys(self.template.placeholders).values():
                         if variable:
                             variable_length += sum(1 if char in SanitiseSMS.ALLOWED_CHARACTERS else 2 for char in str(variable))
                     total_length = variable_length + (len(self.template.content) if self.template else 0)
                     if total_length > SMS_CHAR_COUNT_LIMIT:
-                        rows_too_long.append(row)
-        return (row for row in rows_too_long)
+                        yield row
 
     @property
     def initial_rows_with_errors(self):

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -583,7 +583,7 @@ def validate_sms_message_length(variable_content, template_content_length):
     variable_length = sum(1 if char in SanitiseSMS.ALLOWED_CHARACTERS else 2 for char in variable_content)
 
     if variable_length + len(template_content_length) > SMS_CHAR_COUNT_LIMIT:
-        raise ValueError("Maximum 612 characters. Some messages may be too long due to custom content.")
+        raise ValueError(f"Maximum {SMS_CHAR_COUNT_LIMIT} characters. Some messages may be too long due to custom content.")
     return
 
 

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -378,6 +378,9 @@ class RecipientCSV:
         if value in [None, ""]:
             return Cell.missing_field_error
 
+        if len(value) + len(self.template.content) > 612:
+            return Cell.message_too_long
+
 
 class InvalidEmailError(Exception):
     def __init__(self, message=None):

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -282,7 +282,7 @@ class RecipientCSV:
         Checks if the length of all variable, plus the length of the template content,
         exceeds the SMS limit of 612 characters. Counts non-GSM characters as 2.
         """
-        result = []
+        rows_too_long = []
         if self.rows_as_list:
             for row in self.rows_as_list:
                 if row.personalisation and self.template and self.template.placeholders:
@@ -292,8 +292,8 @@ class RecipientCSV:
                             variable_length += sum(1 if char in SanitiseSMS.ALLOWED_CHARACTERS else 2 for char in str(variable))
                     total_length = variable_length + (len(self.template.content) if self.template else 0)
                     if total_length > 612:
-                        result.append(row)
-        return result
+                        rows_too_long.append(row)
+        return (row for row in rows_too_long)
 
     @property
     def initial_rows_with_errors(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = '(notifications_utils|tests)/.*\.pyi?$'
 
 [tool.poetry]
 name = "notifications-utils"
-version = "52.1.5"
+version = "52.1.6"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"


### PR DESCRIPTION
# Summary | Résumé
This PR adds validation to the `RecipientCSV` class to ensure that variables inserted do not exceed the 612 character limit, when sending SMS. A new property, `rows_with_combined_variable_content_too_long`, was added to check that the total message length does not exceed 612 when both the variable content and template content is combined.