### PR TITLE
Fix validation bug when phone number in None

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.4
-git+https://github.com/cds-snc/notifier-utils.git@52.1.4#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@52.1.5#egg=notifications-utils

--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.4
-git+https://github.com/cds-snc/notifier-utils.git@52.1.3#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@52.1.4#egg=notifications-utils

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -445,6 +445,8 @@ def validate_local_phone_number(number, column=None):
 
 
 def validate_phone_number(number, column=None, international=False):
+    if number is None:
+        raise InvalidPhoneError("Number is None")
     if ";" in number:
         raise InvalidPhoneError("Not a valid number")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = '(notifications_utils|tests)/.*\.pyi?$'
 
 [tool.poetry]
 name = "notifications-utils"
-version = "52.1.4"
+version = "52.1.5"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = '(notifications_utils|tests)/.*\.pyi?$'
 
 [tool.poetry]
 name = "notifications-utils"
-version = "52.1.3"
+version = "52.1.4"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -251,6 +251,12 @@ def test_phone_with_semicolon(phone):
     assert "Not a valid number" == str(e.value)
 
 
+def test_phone_with_no_number():
+    with pytest.raises(InvalidPhoneError) as e:
+        validate_phone_number(None)
+    assert "Number is None" == str(e.value)
+
+
 @pytest.mark.parametrize("phone_number", valid_phone_numbers)
 @pytest.mark.parametrize(
     "validator",


### PR DESCRIPTION
# Summary | Résumé

[Related issue 305](https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/305)

Fix a validation bug when the number is `None`. Also added a corresponding unit test.

Yes, this is an invalid number, but the [code that is crashing](https://github.com/cds-snc/notification-utils/blob/98bdc0d816e1f269011abec3f2209d743b6147a7/notifications_utils/recipients.py#L471-L481) contains the comment

> For use in places where you shouldn't error if the phone number is invalid - for example if firetext pass us
    something in

Hence raising the error will produce a warning message and return the phone number return as-is, which might be `None` for the caller. The API would receive `None` upon calling this utility.

There are a few places in `api` where this code is used. In these places, either:
- a value of `None` is ok: [here](https://github.com/cds-snc/notification-api/blob/bfadea3bb7ba83cf57d3d206e907b01bfa9239ef/app/models.py#L1123)
- we cannot pass `None` in the function: [here](https://github.com/cds-snc/notification-api/blob/bfadea3bb7ba83cf57d3d206e907b01bfa9239ef/app/dao/notifications_dao.py#L639), [here](https://github.com/cds-snc/notification-api/blob/main/app/inbound_sms/rest.py#L29), and [here](https://github.com/cds-snc/notification-api/blob/bfadea3bb7ba83cf57d3d206e907b01bfa9239ef/app/v2/notifications/post_notifications.py#L646) 