### PR TITLE
Added default PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,26 @@
+# Summary | Résumé
+
+_TODO: 1-3 sentence description of the changed you're proposing._
+
+## Related Issues | Cartes liées
+
+* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1
+* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1
+
+# Test instructions | Instructions pour tester la modification
+
+_TODO: Fill in test instructions for the reviewer._
+
+# Release Instructions | Instructions pour le déploiement
+
+None.
+
+# Reviewer checklist | Liste de vérification du réviseur
+
+- [ ] This PR does not break existing functionality.
+- [ ] This PR does not violate GCNotify's privacy policies.
+- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
+- [ ] This PR does not significantly alter performance.
+- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).
+
+> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.


### PR DESCRIPTION
# Summary | Résumé

Adding a default PR template. There were none for this repository so it should be a welcomed
addition. The template follows latest agreed-upon format as discussed in the dev code review
session and reviewed by [latest PR here](https://github.com/cds-snc/notification-api/pull/2122).

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/304

# Test instructions | Instructions pour tester la modification

None.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.