### PR TITLE
Exclude content length errors from recipient_error prop

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.4
-git+https://github.com/cds-snc/notifier-utils.git@52.1.9#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@52.1.10#egg=notifications-utils

--- a/notifications_utils/columns.py
+++ b/notifications_utils/columns.py
@@ -59,6 +59,9 @@ class Row(Columns):
             else ["phone number", "numéro de téléphone", "to"]
         )
 
+        # This won't mark a row as too long in all cases. A message can be too long if
+        # placeholder content is added by a user that exceeds the limit when added to
+        # the template's content.
         if template:
             template.values = row_dict
             self.message_too_long = template.is_message_too_long()
@@ -144,4 +147,9 @@ class Cell:
 
     @property
     def recipient_error(self):
+        # TODO: This is a bandaid solution. We need to establish why we are calling this Cell property on
+        #       Cells that do not represent a recipient value.
+        if self.error is not None and 'Some messages may be too long due to custom content.' in self.error:
+            return False
+
         return self.error not in {None, self.missing_field_error}

--- a/notifications_utils/columns.py
+++ b/notifications_utils/columns.py
@@ -149,7 +149,7 @@ class Cell:
     def recipient_error(self):
         # TODO: This is a bandaid solution. We need to establish why we are calling this Cell property on
         #       Cells that do not represent a recipient value.
-        if self.error is not None and 'Some messages may be too long due to custom content.' in self.error:
+        if self.error is not None and "Some messages may be too long due to custom content." in self.error:
             return False
 
         return self.error not in {None, self.missing_field_error}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = '(notifications_utils|tests)/.*\.pyi?$'
 
 [tool.poetry]
 name = "notifications-utils"
-version = "52.1.9"
+version = "52.1.10"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"


### PR DESCRIPTION
# Summary | Résumé
The `recipient_error` property was falsely identifying certain row errors as `recipient_errors` and incorrectly marking rows as having recipient errors causing API to mis-interpret what error messages to return to the endpoint caller.

## Related Issues | Cartes liées
This PR addresses an issue that was blocking the release pipeline following bumps to Utils' version in API.

# Test instructions | Instructions pour tester la modification


# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.