### PR TITLE
Feat/add support for custom alt text

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.4
-git+https://github.com/cds-snc/notifier-utils.git@52.2.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@52.2.1#egg=notifications-utils

--- a/notifications_utils/jinja_templates/email/_custom_logo_no_background_colour.jinja2
+++ b/notifications_utils/jinja_templates/email/_custom_logo_no_background_colour.jinja2
@@ -9,7 +9,7 @@
         <tr>
           <td style="padding: 0 10px 0 {% if brand_colour %} 8px; border-left: solid 2px {{ brand_colour }}{% else %} 10px;{% endif %}">
             <img src="{{ brand_logo }}" style="display: block; border: 0" height="{% if brand_text -%} 27 {%- else -%} 108 {%- endif %}"
-                        alt="{% if brand_text %} {% else -%}{{ brand_name }}{%- endif %}" />
+                        alt="{% if alt_text_en %}{{ alt_text_en }} / {{ alt_text_fr }}{% else -%}{{ brand_name}}{%- endif %}" />
           </td>
           {% if brand_text %}
             <td width="100%" style="font-family: Helvetica, Arial, sans-serif; font-size: 18px; line-height: 23px;" valign="center">

--- a/notifications_utils/jinja_templates/email/_custom_logo_with_background_colour.jinja2
+++ b/notifications_utils/jinja_templates/email/_custom_logo_with_background_colour.jinja2
@@ -17,7 +17,7 @@
                 border="0"
                 style="display: block; border: 0;"
                 height="{% if brand_text -%} 27 {%- else -%} 54 {%- endif %}"
-                alt="{% if brand_text %} {% else -%}{{ brand_name }}{%- endif %}"
+                alt="{% if alt_text_en %}{{ alt_text_en }} / {{ alt_text_fr }}{% else -%}{{ brand_name}}{%- endif %}"
               />
             </td>
           {% endif %}

--- a/notifications_utils/jinja_templates/email/email_preview_template.jinja2
+++ b/notifications_utils/jinja_templates/email/email_preview_template.jinja2
@@ -64,7 +64,7 @@
         <img
           src="https://{{ asset_domain }}/{{ brand_logo }}"
           style="padding-left:0; display: block; border: 0; height:{% if brand_text -%} 27 {%- else -%} 108 {%- endif %}px"
-          alt="{% if brand_text %} {% else -%}{{ brand_name }}{%- endif %}"
+          alt="{% if alt_text_en %}{{ alt_text_en }} / {{ alt_text_fr }}{% else -%}{{ brand_name}}{%- endif %}"
         />
         </div>
 

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -363,6 +363,8 @@ class HTMLEmailTemplate(WithSubjectTemplate):
         brand_name=None,
         jinja_path=None,
         allow_html=False,
+        alt_text_en=None,
+        alt_text_fr=None,
     ):
         super().__init__(template, values, jinja_path=jinja_path)
         self.fip_banner_english = fip_banner_english
@@ -374,6 +376,8 @@ class HTMLEmailTemplate(WithSubjectTemplate):
         self.logo_with_background_colour = logo_with_background_colour
         self.brand_name = brand_name
         self.allow_html = allow_html
+        self.alt_text_en = alt_text_en
+        self.alt_text_fr = alt_text_fr
         # set this again to make sure the correct either utils / downstream local jinja is used
         # however, don't set if we are in a test environment (to preserve the above mock)
         if "pytest" not in sys.modules:
@@ -413,6 +417,8 @@ class HTMLEmailTemplate(WithSubjectTemplate):
                 "brand_colour": self.brand_colour,
                 "logo_with_background_colour": self.logo_with_background_colour,
                 "brand_name": self.brand_name,
+                "alt_text_en": self.alt_text_en,
+                "alt_text_fr": self.alt_text_fr,
             }
         )
 
@@ -456,6 +462,8 @@ class EmailPreviewTemplate(WithSubjectTemplate):
         logo_with_background_colour=None,
         asset_domain=None,
         allow_html=False,
+        alt_text_en=None,
+        alt_text_fr=None,
     ):
         super().__init__(
             template,
@@ -476,6 +484,8 @@ class EmailPreviewTemplate(WithSubjectTemplate):
         self.brand_name = brand_name
         self.asset_domain = asset_domain or "assets.notification.canada.ca"
         self.allow_html = allow_html
+        self.alt_text_en = alt_text_en
+        self.alt_text_fr = alt_text_fr
 
     def __str__(self):
         return Markup(
@@ -500,6 +510,8 @@ class EmailPreviewTemplate(WithSubjectTemplate):
                     "brand_text": self.brand_text,
                     "brand_name": self.brand_name,
                     "asset_domain": self.asset_domain,
+                    "alt_text_en": self.alt_text_en,
+                    "alt_text_fr": self.alt_text_fr,
                 }
             )
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = '(notifications_utils|tests)/.*\.pyi?$'
 
 [tool.poetry]
 name = "notifications-utils"
-version = "52.2.0"
+version = "52.2.1"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -144,7 +144,7 @@ def test_alt_text_with_brand_text_and_fip_banner_english_shown(renderer):
             logo_with_background_colour=True,
             brand_name="Notify Logo",
             alt_text_en="alt_text_en",
-            alt_text_fr="alt_text_fr"
+            alt_text_fr="alt_text_fr",
         )
     )
     assert 'alt="alt_text_en / alt_text_fr"' in email
@@ -191,12 +191,14 @@ def test_alt_text_with_no_brand_text_and_fip_banner_french_shown(renderer):
     "logo_with_background_colour, brand_text, alt_text_en, alt_text_fr, expected_alt_text",
     [
         (True, None, None, None, 'alt="Notify Logo"'),
-        (True, "Example", 'alt_text_en', 'alt_text_fr', 'alt="alt_text_en / alt_text_fr"'),
+        (True, "Example", "alt_text_en", "alt_text_fr", 'alt="alt_text_en / alt_text_fr"'),
         (False, "Example", None, None, 'alt="Notify Logo"'),
-        (False, None, 'alt_text_en', 'alt_text_fr', 'alt="alt_text_en / alt_text_fr"'),
+        (False, None, "alt_text_en", "alt_text_fr", 'alt="alt_text_en / alt_text_fr"'),
     ],
 )
-def test_alt_text_with_no_fip_banner(logo_with_background_colour, brand_text, alt_text_en, alt_text_fr, expected_alt_text, renderer):
+def test_alt_text_with_no_fip_banner(
+    logo_with_background_colour, brand_text, alt_text_en, alt_text_fr, expected_alt_text, renderer
+):
     email = str(
         renderer(
             {"content": "hello world", "subject": ""},

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -143,9 +143,11 @@ def test_alt_text_with_brand_text_and_fip_banner_english_shown(renderer):
             brand_text="Example",
             logo_with_background_colour=True,
             brand_name="Notify Logo",
+            alt_text_en="alt_text_en",
+            alt_text_fr="alt_text_fr"
         )
     )
-    assert 'alt=" "' in email
+    assert 'alt="alt_text_en / alt_text_fr"' in email
     assert 'alt="Notify Logo"' not in email
 
 
@@ -159,10 +161,12 @@ def test_alt_text_with_no_brand_text_and_fip_banner_english_shown(renderer):
             brand_text=None,
             logo_with_background_colour=True,
             brand_name="Notify Logo",
+            alt_text_en="alt_text_en",
+            alt_text_fr="alt_text_fr",
         )
     )
     assert 'alt="Symbol of the Government of Canada / Symbole du gouvernement du Canada"' in email
-    assert 'alt="Notify Logo"' in email
+    assert 'alt="alt_text_en / alt_text_fr"' in email
 
 
 @pytest.mark.parametrize("renderer", [HTMLEmailTemplate, EmailPreviewTemplate])
@@ -184,15 +188,15 @@ def test_alt_text_with_no_brand_text_and_fip_banner_french_shown(renderer):
 
 @pytest.mark.parametrize("renderer", [HTMLEmailTemplate, EmailPreviewTemplate])
 @pytest.mark.parametrize(
-    "logo_with_background_colour, brand_text, expected_alt_text",
+    "logo_with_background_colour, brand_text, alt_text_en, alt_text_fr, expected_alt_text",
     [
-        (True, None, 'alt="Notify Logo"'),
-        (True, "Example", 'alt=" "'),
-        (False, "Example", 'alt=" "'),
-        (False, None, 'alt="Notify Logo"'),
+        (True, None, None, None, 'alt="Notify Logo"'),
+        (True, "Example", 'alt_text_en', 'alt_text_fr', 'alt="alt_text_en / alt_text_fr"'),
+        (False, "Example", None, None, 'alt="Notify Logo"'),
+        (False, None, 'alt_text_en', 'alt_text_fr', 'alt="alt_text_en / alt_text_fr"'),
     ],
 )
-def test_alt_text_with_no_fip_banner(logo_with_background_colour, brand_text, expected_alt_text, renderer):
+def test_alt_text_with_no_fip_banner(logo_with_background_colour, brand_text, alt_text_en, alt_text_fr, expected_alt_text, renderer):
     email = str(
         renderer(
             {"content": "hello world", "subject": ""},
@@ -201,6 +205,8 @@ def test_alt_text_with_no_fip_banner(logo_with_background_colour, brand_text, ex
             brand_text=brand_text,
             logo_with_background_colour=logo_with_background_colour,
             brand_name="Notify Logo",
+            alt_text_en=alt_text_en,
+            alt_text_fr=alt_text_fr,
         )
     )
 


### PR DESCRIPTION
# Summary | Résumé
This PR adds support for alt text for custom logos in notify:
- Updates email classes (`HTMLEmailTemplate` & `EmailPreviewTemplate`) to receive new `alt_text_en` and `alt_text_fr` parameters, and pass them through to the jinja templates
- Updates the jinja templates to use new alt text parms them when a custom logo is in use

Note: Although `alt_text_en` and `alt_text_fr` will be mandatory in ADMIN, the code falls back to use `brand_name` as the alt text in the event they aren't provided.

## Related Issues | Cartes liées
* https://github.com/cds-snc/notification-planning/issues/1543

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.