### PR TITLE
Revert "Exclude content length errors from recipient_error prop"

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.4
-git+https://github.com/cds-snc/notifier-utils.git@52.1.10#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@52.1.9#egg=notifications-utils

--- a/notifications_utils/columns.py
+++ b/notifications_utils/columns.py
@@ -59,9 +59,6 @@ class Row(Columns):
             else ["phone number", "numéro de téléphone", "to"]
         )
 
-        # This won't mark a row as too long in all cases. A message can be too long if
-        # placeholder content is added by a user that exceeds the limit when added to
-        # the template's content.
         if template:
             template.values = row_dict
             self.message_too_long = template.is_message_too_long()
@@ -147,9 +144,4 @@ class Cell:
 
     @property
     def recipient_error(self):
-        # TODO: This is a bandaid solution. We need to establish why we are calling this Cell property on
-        #       Cells that do not represent a recipient value.
-        if self.error is not None and "Some messages may be too long due to custom content." in self.error:
-            return False
-
         return self.error not in {None, self.missing_field_error}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ include = '(notifications_utils|tests)/.*\.pyi?$'
 
 [tool.poetry]
 name = "notifications-utils"
-version = "52.1.10"
+version = "52.1.9"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"


### PR DESCRIPTION
Reverts cds-snc/notification-utils#290

We encountered a couple issues where SMS limit checking that was a part of this PR, and [#278](https://github.com/cds-snc/notification-utils/pull/278), was applying to bulk emails when it should only be applicable to bulk SMS.