### PR TITLE
Task/fix template typo

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
-git+https://github.com/cds-snc/notifier-utils.git@52.3.4#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@52.3.5#egg=notifications-utils

--- a/notifications_utils/jinja_templates/email/email_preview_template.jinja2
+++ b/notifications_utils/jinja_templates/email/email_preview_template.jinja2
@@ -75,7 +75,7 @@
         </p>
       {% endif %}
 
-      <div style="padding: 0 10px" dir="{{ 'rtl' if text_direction_rtl else 'ltr' }}"">
+      <div style="padding: 0 10px" dir="{{ 'rtl' if text_direction_rtl else 'ltr' }}">
         {{ body }}
       </div>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "52.3.4"
+version = "52.3.5"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"


### PR DESCRIPTION
# Summary | Résumé

This PR fixes a typo in the jinja template 😿 

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/1551

# Test instructions | Instructions pour tester la modification

- Make sure template doesn't have 2 quotes back to back

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.