### PR TITLE
Annual Limit daily delivered & failed notification counts and seeding implementation

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
-git+https://github.com/cds-snc/notifier-utils.git@52.3.6#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@52.3.7#egg=notifications-utils

--- a/notifications_utils/clients/redis/annual_limit.py
+++ b/notifications_utils/clients/redis/annual_limit.py
@@ -58,6 +58,16 @@ class RedisAnnualLimit:
         """
         return decode_byte_dict(self._redis_client.get_all_from_hash(notifications_key(service_id)))
 
+    def reset_all_notification_counts(self):
+        """
+        Resets all daily notification metrics for all services. Uses non-blocking scan_iter method to avoid locking the Redis server.
+        """
+        pattern = notifications_key("*")  # All notification keys regardless of service_id
+
+        self._redis_client.bulk_set_hash_fields(
+            pattern, ({"email_delivered": 0, "email_failed": 0, "sms_delivered": 0, "sms_failed": 0})
+        )
+
     def clear_notification_counts(self, service_id: str):
         """
         Clears all daily notification metrics for a service.

--- a/notifications_utils/clients/redis/annual_limit.py
+++ b/notifications_utils/clients/redis/annual_limit.py
@@ -57,11 +57,14 @@ def annual_limit_status_key(service_id):
     return f"annual-limit:{service_id}:status"
 
 
-def decode_byte_dict(dict: dict):
+def decode_byte_dict(dict: dict, value_type=str):
     """
     Redis-py returns byte strings for keys and values. This function decodes them to UTF-8 strings.
     """
-    return {key.decode("utf-8"): value.decode("utf-8") for key, value in dict.items()}
+    # Check if expected_value_type is one of the allowed types
+    if value_type not in {int, float, str}:
+        raise ValueError("expected_value_type must be int, float, or str")
+    return {key.decode("utf-8"): value_type(value.decode("utf-8")) for key, value in dict.items()}
 
 
 class RedisAnnualLimit:
@@ -84,7 +87,7 @@ class RedisAnnualLimit:
         """
         Retrieves all daily notification metrics for a service.
         """
-        return decode_byte_dict(self._redis_client.get_all_from_hash(annual_limit_notifications_key(service_id)))
+        return decode_byte_dict(self._redis_client.get_all_from_hash(annual_limit_notifications_key(service_id)), int)
 
     def reset_all_notification_counts(self, service_ids=None):
         """

--- a/notifications_utils/clients/redis/annual_limit.py
+++ b/notifications_utils/clients/redis/annual_limit.py
@@ -102,6 +102,9 @@ class RedisAnnualLimit:
 
         self._redis_client.delete_hash_fields(hashes=hashes)
 
+    def seed_annual_limit_notifications(self, service_id: str, mapping: dict):
+        self._redis_client.bulk_set_hash_fields(key=annual_limit_notifications_key(service_id), mapping=mapping)
+
     def was_seeded_today(self, service_id):
         last_seeded_time = self.get_seeded_at(service_id)
         return last_seeded_time == datetime.utcnow().strftime("%Y-%m-%d") if last_seeded_time else False

--- a/notifications_utils/clients/redis/annual_limit.py
+++ b/notifications_utils/clients/redis/annual_limit.py
@@ -1,4 +1,27 @@
-"""This module stores daily notification counts and annual limit statuses for a service in Redis."""
+"""
+This module stores daily notification counts and annual limit statuses for a service in Redis using a hash structure:
+
+
+annual-limit: {
+    {service_id}: {
+        notifications: {
+            sms_delivered: int,
+            email_delivered: int,
+            sms_failed: int,
+            email_failed: int
+        },
+        status: {
+            near_sms_limit: Datetime,
+            near_email_limit: Datetime,
+            over_sms_limit: Datetime,
+            over_email_limit: Datetime
+            seeded_at: Datetime
+        }
+    }
+}
+
+
+"""
 
 from datetime import datetime
 
@@ -9,13 +32,18 @@ EMAIL_DELIVERED = "email_delivered"
 SMS_FAILED = "sms_failed"
 EMAIL_FAILED = "email_failed"
 
+NOTIFICATIONS = [SMS_DELIVERED, EMAIL_DELIVERED, SMS_FAILED, EMAIL_FAILED]
+
 NEAR_SMS_LIMIT = "near_sms_limit"
 NEAR_EMAIL_LIMIT = "near_email_limit"
 OVER_SMS_LIMIT = "over_sms_limit"
 OVER_EMAIL_LIMIT = "over_email_limit"
+SEEDED_AT = "seeded_at"
+
+STATUSES = [NEAR_SMS_LIMIT, NEAR_EMAIL_LIMIT, OVER_SMS_LIMIT, OVER_EMAIL_LIMIT]
 
 
-def notifications_key(service_id):
+def annual_limit_notifications_key(service_id):
     """
     Generates the Redis hash key for storing daily metrics of a service.
     """
@@ -44,35 +72,48 @@ class RedisAnnualLimit:
         pass
 
     def increment_notification_count(self, service_id: str, field: str):
-        self._redis_client.increment_hash_value(notifications_key(service_id), field)
+        self._redis_client.increment_hash_value(annual_limit_notifications_key(service_id), field)
 
     def get_notification_count(self, service_id: str, field: str):
         """
         Retrieves the specified daily notification count for a service. (e.g. SMS_DELIVERED, EMAIL_FAILED, etc.)
         """
-        return int(self._redis_client.get_hash_field(notifications_key(service_id), field))
+        return int(self._redis_client.get_hash_field(annual_limit_notifications_key(service_id), field))
 
     def get_all_notification_counts(self, service_id: str):
         """
         Retrieves all daily notification metrics for a service.
         """
-        return decode_byte_dict(self._redis_client.get_all_from_hash(notifications_key(service_id)))
+        return decode_byte_dict(self._redis_client.get_all_from_hash(annual_limit_notifications_key(service_id)))
 
-    def reset_all_notification_counts(self):
+    def reset_all_notification_counts(self, service_ids=None):
         """
-        Resets all daily notification metrics for all services. Uses non-blocking scan_iter method to avoid locking the Redis server.
+        Resets all daily notification metrics.
+        :param: service_ids: list of service_ids to reset, if None, resets all services
         """
-        pattern = notifications_key("*")  # All notification keys regardless of service_id
-
-        self._redis_client.bulk_set_hash_fields(
-            pattern, ({"email_delivered": 0, "email_failed": 0, "sms_delivered": 0, "sms_failed": 0})
+        hashes = (
+            annual_limit_notifications_key("*")
+            if not service_ids
+            else [annual_limit_notifications_key(service_id) for service_id in service_ids]
         )
+
+        self._redis_client.delete_hash_fields(hashes=hashes)
+
+    def was_seeded_today(self, service_id):
+        last_seeded_time = self.get_seeded_at(service_id)
+        return last_seeded_time == datetime.utcnow().strftime("%Y-%m-%d") if last_seeded_time else False
+
+    def get_seeded_at(self, service_id: str):
+        return self._redis_client.get_hash_field(annual_limit_status_key(service_id), SEEDED_AT).decode("utf-8")
+
+    def set_seeded_at(self, service_id):
+        self._redis_client.set_hash_value(annual_limit_status_key(service_id), SEEDED_AT, datetime.utcnow().strftime("%Y-%m-%d"))
 
     def clear_notification_counts(self, service_id: str):
         """
         Clears all daily notification metrics for a service.
         """
-        self._redis_client.expire(notifications_key(service_id), -1)
+        self._redis_client.expire(annual_limit_notifications_key(service_id), -1)
 
     def set_annual_limit_status(self, service_id: str, field: str, value: datetime):
         """

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -1,7 +1,7 @@
 import numbers
 import uuid
 from time import time
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from flask import current_app
 from flask_redis import FlaskRedis
@@ -82,7 +82,7 @@ class RedisClient:
         return 0
 
     # TODO: Refactor and simplify this to use HEXPIRE when we upgrade Redis to 7.4.0
-    def delete_hash_fields(self, hashes: (str | list), fields: list = None, raise_exception=False):
+    def delete_hash_fields(self, hashes: (str | list), fields: Optional[list] = None, raise_exception=False):
         """Deletes fields from the specified hashes. if fields is `None`, then all fields from the hashes are deleted, deleting the hash entirely.
 
         Args:

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -119,8 +119,7 @@ class RedisClient:
                 return result
             except Exception as e:
                 self.__handle_exception(e, raise_exception, "expire_hash_fields", hashes)
-        else:
-            return False
+        return False
 
     def bulk_set_hash_fields(self, mapping, pattern=None, key=None, raise_exception=False):
         """
@@ -135,9 +134,10 @@ class RedisClient:
                     for key in self.redis_store.scan_iter(pattern):
                         self.redis_store.hmset(key, mapping)
                 if key:
-                    self.redis_store.hmset(key, mapping)
+                    return self.redis_store.hmset(key, mapping)
             except Exception as e:
                 self.__handle_exception(e, raise_exception, "bulk_set_hash_fields", pattern)
+        return False
 
     def exceeded_rate_limit(self, cache_key, limit, interval, raise_exception=False):
         """
@@ -293,9 +293,11 @@ class RedisClient:
 
         if self.active:
             try:
-                self.redis_store.hset(key, field, value)
+                return self.redis_store.hset(key, field, value)
             except Exception as e:
                 self.__handle_exception(e, raise_exception, "set_hash_value", key)
+
+        return None
 
     def decrement_hash_value(self, key, value, raise_exception=False):
         return self.increment_hash_value(key, value, raise_exception, incr_by=-1)
@@ -331,6 +333,8 @@ class RedisClient:
             except Exception as e:
                 self.__handle_exception(e, raise_exception, "get_all_from_hash", key)
 
+        return None
+
     def set_hash_and_expire(self, key, values, expire_in_seconds, raise_exception=False):
         key = prepare_value(key)
         values = {prepare_value(k): prepare_value(v) for k, v in values.items()}
@@ -340,6 +344,8 @@ class RedisClient:
                 return self.redis_store.expire(key, expire_in_seconds)
             except Exception as e:
                 self.__handle_exception(e, raise_exception, "set_hash_and_expire", key)
+
+        return None
 
     def expire(self, key, expire_in_seconds, raise_exception=False):
         key = prepare_value(key)

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -81,6 +81,20 @@ class RedisClient:
             return self.scripts["delete-keys-by-pattern"](args=[pattern])
         return 0
 
+    def bulk_set_hash_fields(self, pattern, mapping, raise_exception=False):
+        """
+        Bulk set hash fields.
+        :param pattern: the pattern to match keys
+        :param mappting: the mapping of fields to set
+        :param raise_exception: True if we should allow the exception to bubble up
+        """
+        if self.active:
+            try:
+                for key in self.redis_store.scan_iter(pattern):
+                    self.redis_store.hmset(key, mapping)
+            except Exception as e:
+                self.__handle_exception(e, raise_exception, "bulk_set_hash_fields", pattern)
+
     def exceeded_rate_limit(self, cache_key, limit, interval, raise_exception=False):
         """
         Rate limiting.

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -113,37 +113,13 @@ class RedisClient:
                     key = prepare_value(key)
                     pipe.hdel(key, *fields)
                 result = pipe.execute()
+                # TODO: May need to double check that the pipeline result count matches the number of hashes deleted
+                # and retry any failures
                 return result
             except Exception as e:
                 self.__handle_exception(e, raise_exception, "expire_hash_fields", hashes)
-
-    def set_hash_fields_by_pattern_or_keys(self, mapping, keys: str | list = None, raise_exception=False):
-        """
-        Bulk set hash fields.
-        :param pattern: the pattern to match keys or a list of keys to set
-        :param mappting: the mapping of fields to set
-        :param raise_exception: True if we should allow the exception to bubble up
-        """
-        if self.active:
-            try:
-                for key in self.redis_store.hscan_iter(keys):
-                    self.redis_store.hmset(key, mapping)
-            except Exception as e:
-                self.__handle_exception(e, raise_exception, "bulk_set_hash_fields", keys)
-
-    def set_hash_fields_by_keys(self, keys, mapping, raise_exception=False):
-        """
-        Bulk set hash fields.
-        :param pattern: the pattern to match keys
-        :param mappting: the mapping of fields to set
-        :param raise_exception: True if we should allow the exception to bubble up
-        """
-        if self.active:
-            try:
-                for key in self.redis_store.scan_iter(keys):
-                    self.redis_store.hmset(key, mapping)
-            except Exception as e:
-                self.__handle_exception(e, raise_exception, "bulk_set_hash_fields", keys)
+        else:
+            return False
 
     def exceeded_rate_limit(self, cache_key, limit, interval, raise_exception=False):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "52.3.6"
+version = "52.3.7"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_annual_limit.py
+++ b/tests/test_annual_limit.py
@@ -127,6 +127,31 @@ def test_clear_notification_counts(mock_annual_limit_client, mock_notification_c
     assert len(mock_annual_limit_client.get_all_notification_counts(mocked_service_id)) == 0
 
 
+@pytest.mark.parametrize(
+    "service_ids",
+    [
+        [
+            str(uuid.uuid4()),
+            str(uuid.uuid4()),
+            str(uuid.uuid4()),
+            str(uuid.uuid4()),
+        ]
+    ],
+)
+def test_bulk_reset_notification_counts(mock_annual_limit_client, mock_notification_count_types, service_ids):
+    for service_id in service_ids:
+        for field in mock_notification_count_types:
+            mock_annual_limit_client.increment_notification_count(service_id, field)
+        assert len(mock_annual_limit_client.get_all_notification_counts(service_id)) == 4
+
+    mock_annual_limit_client.reset_all_notification_counts()
+
+    for service_id in service_ids:
+        assert len(mock_annual_limit_client.get_all_notification_counts(service_id)) == 4
+        for field in mock_notification_count_types:
+            assert mock_annual_limit_client.get_notification_count(service_id, field) == 0
+
+
 def test_set_annual_limit_status(mock_annual_limit_client, mocked_service_id):
     mock_annual_limit_client.set_annual_limit_status(mocked_service_id, NEAR_SMS_LIMIT, datetime.utcnow())
     result = mock_annual_limit_client.get_annual_limit_status(mocked_service_id, NEAR_SMS_LIMIT)

--- a/tests/test_annual_limit.py
+++ b/tests/test_annual_limit.py
@@ -147,9 +147,7 @@ def test_bulk_reset_notification_counts(mock_annual_limit_client, mock_notificat
     mock_annual_limit_client.reset_all_notification_counts()
 
     for service_id in service_ids:
-        assert len(mock_annual_limit_client.get_all_notification_counts(service_id)) == 4
-        for field in mock_notification_count_types:
-            assert mock_annual_limit_client.get_notification_count(service_id, field) == 0
+        assert len(mock_annual_limit_client.get_all_notification_counts(service_id)) == 0
 
 
 def test_set_annual_limit_status(mock_annual_limit_client, mocked_service_id):

--- a/tests/test_annual_limit.py
+++ b/tests/test_annual_limit.py
@@ -15,8 +15,8 @@ from notifications_utils.clients.redis.annual_limit import (
     SMS_DELIVERED,
     SMS_FAILED,
     RedisAnnualLimit,
+    annual_limit_notifications_key,
     annual_limit_status_key,
-    notifications_key,
 )
 from notifications_utils.clients.redis.redis_client import RedisClient
 
@@ -79,7 +79,7 @@ def mocked_service_id():
 
 def test_notifications_key(mocked_service_id):
     expected_key = f"annual-limit:{mocked_service_id}:notifications"
-    assert notifications_key(mocked_service_id) == expected_key
+    assert annual_limit_notifications_key(mocked_service_id) == expected_key
 
 
 def test_annual_limits_key(mocked_service_id):

--- a/tests/test_redis_client.py
+++ b/tests/test_redis_client.py
@@ -33,6 +33,27 @@ def better_mocked_redis_client(app):
     return redis_client
 
 
+@pytest.fixture(scope="function")
+def mocked_hash_structure():
+    return {
+        "key1": {
+            "field1": "value1",
+            "field2": 2,
+            "field3": "value3".encode("utf-8"),
+        },
+        "key2": {
+            "field1": "value1",
+            "field2": 2,
+            "field3": "value3".encode("utf-8"),
+        },
+        "key3": {
+            "field1": "value1",
+            "field2": 2,
+            "field3": "value3".encode("utf-8"),
+        },
+    }
+
+
 def build_redis_client(app, mocked_redis_pipeline, mocker):
     redis_client = RedisClient()
     redis_client.init_app(app)
@@ -168,105 +189,6 @@ def test_should_build_rate_limit_cache_key(sample_service):
     assert rate_limit_cache_key(sample_service.id, "TEST") == "{}-TEST".format(sample_service.id)
 
 
-def test_get_hash_field(mocked_redis_client):
-    key = "12345"
-    field = "template-1111"
-    mocked_redis_client.redis_store.hget = Mock(return_value=b"8")
-    assert mocked_redis_client.get_hash_field(key, field) == b"8"
-    mocked_redis_client.redis_store.hget.assert_called_with(key, field)
-
-
-def test_set_hash_value(mocked_redis_client):
-    key = "12345"
-    field = "template-1111"
-    value = 8
-    mocked_redis_client.set_hash_value(key, field, value)
-    mocked_redis_client.redis_store.hset.assert_called_with(key, field, value)
-
-
-@pytest.mark.parametrize(
-    "hash, updates, expected",
-    [
-        (
-            {
-                "key1": {
-                    "field1": "value1",
-                    "field2": 2,
-                    "field3": "value3".encode("utf-8"),
-                },
-                "key2": {
-                    "field1": "value1",
-                    "field2": 2,
-                    "field3": "value3".encode("utf-8"),
-                },
-                "key3": {
-                    "field1": "value1",
-                    "field2": 2,
-                    "field3": "value3".encode("utf-8"),
-                },
-            },
-            {
-                "field1": "value2",
-                "field2": 3,
-                "field3": "value4".encode("utf-8"),
-            },
-            {
-                b"field1": b"value2",
-                b"field2": b"3",
-                b"field3": b"value4",
-            },
-        )
-    ],
-)
-def test_bulk_set_hash_fields(better_mocked_redis_client, hash, updates, expected):
-    for key, fields in hash.items():
-        for field, value in fields.items():
-            better_mocked_redis_client.set_hash_value(key, field, value)
-
-    better_mocked_redis_client.bulk_set_hash_fields("key*", mapping=updates)
-
-    for key, _ in hash.items():
-        assert better_mocked_redis_client.redis_store.hgetall(key) == expected
-
-
-def test_decrement_hash_value_should_decrement_value_by_one_for_key(mocked_redis_client):
-    key = "12345"
-    value = "template-1111"
-
-    mocked_redis_client.decrement_hash_value(key, value, -1)
-    mocked_redis_client.redis_store.hincrby.assert_called_with(key, value, -1)
-
-
-def test_incr_hash_value_should_increment_value_by_one_for_key(mocked_redis_client):
-    key = "12345"
-    value = "template-1111"
-
-    mocked_redis_client.increment_hash_value(key, value)
-    mocked_redis_client.redis_store.hincrby.assert_called_with(key, value, 1)
-
-
-def test_get_all_from_hash_returns_hash_for_key(mocked_redis_client):
-    key = "12345"
-    assert mocked_redis_client.get_all_from_hash(key) == {b"template-1111": b"8", b"template-2222": b"8"}
-    mocked_redis_client.redis_store.hgetall.assert_called_with(key)
-
-
-def test_set_hash_and_expire(mocked_redis_client):
-    key = "hash-key"
-    values = {"key": 10}
-    mocked_redis_client.set_hash_and_expire(key, values, 1)
-    mocked_redis_client.redis_store.hmset.assert_called_with(key, values)
-    mocked_redis_client.redis_store.expire.assert_called_with(key, 1)
-
-
-def test_set_hash_and_expire_converts_values_to_valid_types(mocked_redis_client):
-    key = "hash-key"
-    values = {uuid.UUID(int=0): 10}
-    mocked_redis_client.set_hash_and_expire(key, values, 1)
-    mocked_redis_client.redis_store.hmset.assert_called_with(key, {"00000000-0000-0000-0000-000000000000": 10})
-    mocked_redis_client.redis_store.expire.assert_called_with(key, 1)
-
-
 @freeze_time("2001-01-01 12:00:00.000000")
 def test_should_add_correct_calls_to_the_pipe(mocked_redis_client, mocked_redis_pipeline):
     mocked_redis_client.exceeded_rate_limit("key", 100, 100)
@@ -377,3 +299,131 @@ class TestRedisSortedSets:
         better_mocked_redis_client.active = False
         ret = better_mocked_redis_client.get_length_of_sorted_set("cache_key", min_score=0, max_score=100)
         assert ret == 0
+
+
+class TestRedisHashes:
+    @pytest.mark.parametrize(
+        "hash_key, fields_to_delete, expected_deleted, check_if_no_longer_exists",
+        [
+            ("test:hash:key1", ["field1", "field2"], 2, False),  # Delete specific fields in a hash
+            ("test:hash:key1", None, 3, True),  # Delete All fields in a specific hash
+            ("test:hash:*", ["field1", "field2"], 6, False),  # Delete specific fields in a group of hashes
+            ("test:hash:*", None, 9, True),  # Delete All fields in a group of hashes
+        ],
+    )
+    def test_delete_hash_fields(
+        self,
+        better_mocked_redis_client,
+        hash_key,
+        fields_to_delete,
+        expected_deleted,
+        check_if_no_longer_exists,
+        mocked_hash_structure,
+    ):
+        # set up the hashes to be deleted
+        for key, fields in mocked_hash_structure.items():
+            better_mocked_redis_client.bulk_set_hash_fields(key=f"test:hash:{key}", mapping=fields)
+
+        num_deleted = better_mocked_redis_client.delete_hash_fields(hashes=hash_key, fields=fields_to_delete)
+
+        # Deleting all hash fields by pattern
+        if check_if_no_longer_exists and "*" in hash_key:
+            for key in mocked_hash_structure.keys():
+                assert better_mocked_redis_client.redis_store.exists(f"test:hash:{key}") == 0
+        # Deleting a specific hash
+        elif check_if_no_longer_exists:
+            assert better_mocked_redis_client.redis_store.exists(f"test:hash:{hash_key}") == 0
+
+        # Make sure we've deleted the correct number of fields
+        assert sum(num_deleted) == expected_deleted
+
+    def test_get_hash_field(self, mocked_redis_client):
+        key = "12345"
+        field = "template-1111"
+        mocked_redis_client.redis_store.hget = Mock(return_value=b"8")
+        assert mocked_redis_client.get_hash_field(key, field) == b"8"
+        mocked_redis_client.redis_store.hget.assert_called_with(key, field)
+
+    def test_set_hash_value(self, mocked_redis_client):
+        key = "12345"
+        field = "template-1111"
+        value = 8
+        mocked_redis_client.set_hash_value(key, field, value)
+        mocked_redis_client.redis_store.hset.assert_called_with(key, field, value)
+
+    @pytest.mark.parametrize(
+        "hash, updates, expected",
+        [
+            (
+                {
+                    "key1": {
+                        "field1": "value1",
+                        "field2": 2,
+                        "field3": "value3".encode("utf-8"),
+                    },
+                    "key2": {
+                        "field1": "value1",
+                        "field2": 2,
+                        "field3": "value3".encode("utf-8"),
+                    },
+                    "key3": {
+                        "field1": "value1",
+                        "field2": 2,
+                        "field3": "value3".encode("utf-8"),
+                    },
+                },
+                {
+                    "field1": "value2",
+                    "field2": 3,
+                    "field3": "value4".encode("utf-8"),
+                },
+                {
+                    b"field1": b"value2",
+                    b"field2": b"3",
+                    b"field3": b"value4",
+                },
+            )
+        ],
+    )
+    def test_bulk_set_hash_fields(self, better_mocked_redis_client, hash, updates, expected):
+        for key, fields in hash.items():
+            for field, value in fields.items():
+                better_mocked_redis_client.set_hash_value(key, field, value)
+
+        better_mocked_redis_client.bulk_set_hash_fields(pattern="key*", mapping=updates)
+
+        for key, _ in hash.items():
+            assert better_mocked_redis_client.redis_store.hgetall(key) == expected
+
+    def test_decrement_hash_value_should_decrement_value_by_one_for_key(self, mocked_redis_client):
+        key = "12345"
+        value = "template-1111"
+
+        mocked_redis_client.decrement_hash_value(key, value, -1)
+        mocked_redis_client.redis_store.hincrby.assert_called_with(key, value, -1)
+
+    def test_incr_hash_value_should_increment_value_by_one_for_key(self, mocked_redis_client):
+        key = "12345"
+        value = "template-1111"
+
+        mocked_redis_client.increment_hash_value(key, value)
+        mocked_redis_client.redis_store.hincrby.assert_called_with(key, value, 1)
+
+    def test_get_all_from_hash_returns_hash_for_key(self, mocked_redis_client):
+        key = "12345"
+        assert mocked_redis_client.get_all_from_hash(key) == {b"template-1111": b"8", b"template-2222": b"8"}
+        mocked_redis_client.redis_store.hgetall.assert_called_with(key)
+
+    def test_set_hash_and_expire(self, mocked_redis_client):
+        key = "hash-key"
+        values = {"key": 10}
+        mocked_redis_client.set_hash_and_expire(key, values, 1)
+        mocked_redis_client.redis_store.hmset.assert_called_with(key, values)
+        mocked_redis_client.redis_store.expire.assert_called_with(key, 1)
+
+    def test_set_hash_and_expire_converts_values_to_valid_types(self, mocked_redis_client):
+        key = "hash-key"
+        values = {uuid.UUID(int=0): 10}
+        mocked_redis_client.set_hash_and_expire(key, values, 1)
+        mocked_redis_client.redis_store.hmset.assert_called_with(key, {"00000000-0000-0000-0000-000000000000": 10})
+        mocked_redis_client.redis_store.expire.assert_called_with(key, 1)

--- a/tests/test_redis_client.py
+++ b/tests/test_redis_client.py
@@ -184,6 +184,51 @@ def test_set_hash_value(mocked_redis_client):
     mocked_redis_client.redis_store.hset.assert_called_with(key, field, value)
 
 
+@pytest.mark.parametrize(
+    "hash, updates, expected",
+    [
+        (
+            {
+                "key1": {
+                    "field1": "value1",
+                    "field2": 2,
+                    "field3": "value3".encode("utf-8"),
+                },
+                "key2": {
+                    "field1": "value1",
+                    "field2": 2,
+                    "field3": "value3".encode("utf-8"),
+                },
+                "key3": {
+                    "field1": "value1",
+                    "field2": 2,
+                    "field3": "value3".encode("utf-8"),
+                },
+            },
+            {
+                "field1": "value2",
+                "field2": 3,
+                "field3": "value4".encode("utf-8"),
+            },
+            {
+                b"field1": b"value2",
+                b"field2": b"3",
+                b"field3": b"value4",
+            },
+        )
+    ],
+)
+def test_bulk_set_hash_fields(better_mocked_redis_client, hash, updates, expected):
+    for key, fields in hash.items():
+        for field, value in fields.items():
+            better_mocked_redis_client.set_hash_value(key, field, value)
+
+    better_mocked_redis_client.bulk_set_hash_fields("key*", mapping=updates)
+
+    for key, _ in hash.items():
+        assert better_mocked_redis_client.redis_store.hgetall(key) == expected
+
+
 def test_decrement_hash_value_should_decrement_value_by_one_for_key(mocked_redis_client):
     key = "12345"
     value = "template-1111"


### PR DESCRIPTION
# Summary | Résumé
This PR completes the annual limit Redis client.
- New base functionality available to all Redis clients to bulk update / delete Hash fields
    - Fields can be manipulated via a list of keys or by using a key pattern
- Set and check the seeded_at values for notification counts
- Clear / reset daily notification counts

This will be called during `create_nightly_notification_status_for_day` to reset daily `failed` and `delivered` counts in Redis.

## Related Issues | Cartes liées

# Test instructions | Instructions pour tester la modification

Tests pass & integrates with API.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.