### PR TITLE
Fix seeding bugs add missing tests

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
-git+https://github.com/cds-snc/notifier-utils.git@52.3.7#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@52.3.8#egg=notifications-utils

--- a/notifications_utils/clients/redis/annual_limit.py
+++ b/notifications_utils/clients/redis/annual_limit.py
@@ -64,7 +64,7 @@ def decode_byte_dict(dict: dict, value_type=str):
     # Check if expected_value_type is one of the allowed types
     if value_type not in {int, float, str}:
         raise ValueError("expected_value_type must be int, float, or str")
-    return {key.decode("utf-8"): value_type(value.decode("utf-8")) for key, value in dict.items()}
+    return {key.decode("utf-8"): value_type(value.decode("utf-8")) for key, value in dict.items() if dict.items()}
 
 
 class RedisAnnualLimit:
@@ -110,7 +110,8 @@ class RedisAnnualLimit:
         return last_seeded_time == datetime.utcnow().strftime("%Y-%m-%d") if last_seeded_time else False
 
     def get_seeded_at(self, service_id: str):
-        return self._redis_client.get_hash_field(annual_limit_status_key(service_id), SEEDED_AT).decode("utf-8")
+        seeded_at = self._redis_client.get_hash_field(annual_limit_status_key(service_id), SEEDED_AT)
+        return seeded_at and seeded_at.decode("utf-8")
 
     def set_seeded_at(self, service_id):
         self._redis_client.set_hash_value(annual_limit_status_key(service_id), SEEDED_AT, datetime.utcnow().strftime("%Y-%m-%d"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "52.3.7"
+version = "52.3.8"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_annual_limit.py
+++ b/tests/test_annual_limit.py
@@ -174,6 +174,29 @@ def test_clear_annual_limit_statuses(mock_annual_limit_client, mock_annual_limit
 
 
 @freeze_time("2024-10-25 12:00:00.000000")
+@pytest.mark.parametrize("seeded_at_value, expected_value", [(b"2024-10-25", True), (None, False)])
+def test_was_seeded_today(mock_annual_limit_client, seeded_at_value, expected_value, mocked_service_id, mocker):
+    mocker.patch.object(mock_annual_limit_client._redis_client, "get_hash_field", return_value=seeded_at_value)
+    result = mock_annual_limit_client.was_seeded_today(mocked_service_id)
+    assert result == expected_value
+
+
+@freeze_time("2024-10-25 12:00:00.000000")
+def test_set_seeded_at(mock_annual_limit_client, mocked_service_id):
+    mock_annual_limit_client.set_seeded_at(mocked_service_id)
+    result = mock_annual_limit_client.get_seeded_at(mocked_service_id)
+    assert result == datetime.utcnow().strftime("%Y-%m-%d")
+
+
+@freeze_time("2024-10-25 12:00:00.000000")
+@pytest.mark.parametrize("seeded_at_value, expected_value", [(b"2024-10-25", "2024-10-25"), (None, None)])
+def test_get_seeded_at(mock_annual_limit_client, seeded_at_value, expected_value, mocked_service_id, mocker):
+    mocker.patch.object(mock_annual_limit_client._redis_client, "get_hash_field", return_value=seeded_at_value)
+    result = mock_annual_limit_client.get_seeded_at(mocked_service_id)
+    assert result == expected_value
+
+
+@freeze_time("2024-10-25 12:00:00.000000")
 def test_set_nearing_sms_limit(mock_annual_limit_client, mocked_service_id):
     mock_annual_limit_client.set_nearing_sms_limit(mocked_service_id)
     result = mock_annual_limit_client.get_annual_limit_status(mocked_service_id, NEAR_SMS_LIMIT)


### PR DESCRIPTION
# Summary | Résumé

This PR fixes an issue with the annual limit client. [Related alarm](https://gcdigital.slack.com/archives/C012W5K734Y/p1731530766936449?thread_ts=1731530661.925669&cid=C012W5K734Y) that caught this.

## Related Issues | Cartes liées
* https://github.com/cds-snc/notification-utils/pull/333
* https://github.com/cds-snc/notification-api/pull/2344
* 

# Test instructions | Instructions pour tester la modification

Tests pass, issue in staging is resolved.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.