### PR TITLE
Fix bug in delete_hash_fields

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
-git+https://github.com/cds-snc/notifier-utils.git@52.3.9#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@52.4.0#egg=notifications-utils

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -1,7 +1,7 @@
 import numbers
 import uuid
 from time import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from flask import current_app
 from flask_redis import FlaskRedis
@@ -82,7 +82,7 @@ class RedisClient:
         return 0
 
     # TODO: Refactor and simplify this to use HEXPIRE when we upgrade Redis to 7.4.0
-    def delete_hash_fields(self, hashes: (str | list), fields: Optional[list] = None, raise_exception=False):
+    def delete_hash_fields(self, hashes: (str | list), fields: list, raise_exception=False):
         """Deletes fields from the specified hashes. if fields is `None`, then all fields from the hashes are deleted, deleting the hash entirely.
 
         Args:
@@ -98,13 +98,7 @@ class RedisClient:
                 # When fields are passed in, use the list as is
                 # When hashes is a list, and no fields are passed in, fetch the fields from the first hash in the list
                 # otherwise we know we're going scan iterate over a pattern so we'll fetch the fields on the first pass in the loop below
-                fields = (
-                    [prepare_value(f) for f in fields]
-                    if fields is not None
-                    else self.redis_store.hkeys(hashes[0])
-                    if isinstance(hashes, list)
-                    else None
-                )
+                fields = [prepare_value(f) for f in fields]
                 # Use a pipeline to atomically delete fields from each hash.
                 pipe = self.redis_store.pipeline()
                 # if hashes is not a list, we're scan iterating over keys matching a pattern

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "52.3.9"
+version = "52.4.0"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_redis_client.py
+++ b/tests/test_redis_client.py
@@ -306,9 +306,7 @@ class TestRedisHashes:
         "hash_key, fields_to_delete, expected_deleted, check_if_no_longer_exists",
         [
             ("test:hash:key1", ["field1", "field2"], 2, False),  # Delete specific fields in a hash
-            ("test:hash:key1", None, 3, True),  # Delete All fields in a specific hash
             ("test:hash:*", ["field1", "field2"], 6, False),  # Delete specific fields in a group of hashes
-            ("test:hash:*", None, 9, True),  # Delete All fields in a group of hashes
         ],
     )
     def test_delete_hash_fields(


### PR DESCRIPTION
# Summary | Résumé
A bug in `delete_hash_fields` caused it to consistently fail clearing all fields in a hash. The method optionally took in a mapping of fields to search for and delete. If the mapping was `None` it checked one of the hash keys to obtain the list of fields to delete. In the case of annual limits, there is no guarantee that all service's hashes in Redis will contain all possible fields (sms_delivered, sms_failed, email_delivered, email_failed).
- The fields mapping parameter is no longer optional 

Refactored annual limit client methods that returned numeric data to return 0 instead of None when no data was found in the queried hash e.g: `get_all_notification_counts()` used to return `None` if no fields were found in the hash, it now returns a dict with the expected fields initialized to 0:
```python
{
    sms_delivered: 0,
    email_delivered: 0,
    sms_failed: 0,
    email_failed: 0
}
```

Similarly, when calling `get_all_annual_limit_statuses()`, a structured dict is returned with the values set to `None`
```
{
    near_sms_limit: None,
    near_email_limit: None,
    over_sms_limit: None,
    over_email_limit: None 
    seeded_at: None
}
```

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1
* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/1

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.