### PR TITLE
add setuptools to waffles requirements.txt

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -2,4 +2,4 @@ docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
 setuptools==75.6.0 # required for distutils in Python 3.12
-git+https://github.com/cds-snc/notifier-utils.git@53.0.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@53.0.1#egg=notifications-utils

--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -1,4 +1,5 @@
 docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
+setuptools==75.6.0 # required for distutils in Python 3.12
 git+https://github.com/cds-snc/notifier-utils.git@53.0.0#egg=notifications-utils

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "53.0.0"
+version = "53.0.1"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"


### PR DESCRIPTION
# Summary | Résumé

Python 3.12 doesn't include distutils anymore so we need to get it from somewhere else. [Setuptools is recommended](https://stackoverflow.com/questions/77233855/why-did-i-get-an-error-modulenotfounderror-no-module-named-distutils).

[Tested the action in the admin 3.12 branch](https://github.com/cds-snc/notification-admin/actions/runs/12128468332/job/33814890096?pr=1996). failed with waffles 53.0.0 but works with waffles from this branch.


## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-core-6411dfb7c95fb80014e0cab0/issues/gh/cds-snc/notification-planning-core/464

# Test instructions | Instructions pour tester la modification

Look at https://github.com/cds-snc/notification-admin/actions/runs/12128468332/job/33814890096?pr=1996

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.