### PR TITLE
Fix the preview formatting when a variable appears in a link url

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -2,4 +2,4 @@ docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
 setuptools==75.6.0 # required for distutils in Python 3.12
-git+https://github.com/cds-snc/notifier-utils.git@53.0.3#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@53.0.4#egg=notifications-utils

--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -2,4 +2,4 @@ docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
 setuptools==75.6.0 # required for distutils in Python 3.12
-git+https://github.com/cds-snc/notifier-utils.git@53.0.2#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@53.0.3#egg=notifications-utils

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -25,6 +25,10 @@ class Placeholder:
     def is_conditional(self):
         return "??" in self.body
 
+    def is_in_link_href(self):
+        # this function is just a placeholder - obviously I can't rely on the variable being named "url_var"
+        return "url_var" in self.body
+
     @property
     def name(self):
         # for non conditionals, name equals body
@@ -38,12 +42,21 @@ class Placeholder:
         else:
             raise ValueError("{} not conditional".format(self))
 
+    @property
+    def href_text(self):
+        if self.is_in_link_href():
+            return self.body.replace("((", "").replace("))", "")
+
     def get_conditional_body(self, show_conditional):
         # note: unsanitised/converted
         if self.is_conditional():
             return self.conditional_text if str2bool(show_conditional) else ""
         else:
             raise ValueError("{} not conditional".format(self))
+
+    def get_href_body(self):
+        if self.is_in_link_href():
+            return self.href_text
 
     def __repr__(self):
         return "Placeholder({})".format(self.body)
@@ -119,6 +132,9 @@ class Field:
             return self.conditional_placeholder_tag.format(
                 self.sanitizer(placeholder.name), self.sanitizer(placeholder.conditional_text)
             )
+
+        if placeholder.is_in_link_href():
+            return placeholder.get_href_body()
 
         return self.placeholder_tag.format(self.sanitizer(placeholder.name))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "53.0.3"
+version = "53.0.4"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "53.0.2"
+version = "53.0.3"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -54,11 +54,6 @@ class TestVariablesInLinks:
         rendered_markdown = html.get_text()
         assert rendered_markdown == expected_html
 
-    (
-        "[link text with ((variable))](https://developer.mozilla.org/en-US/)",
-        {},
-    )
-
     @pytest.mark.parametrize(
         "template_content,variable,expected_link_text,expected_href",
         [

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -42,14 +42,14 @@ def test_lang_tags_in_templates_good_content(good_content: str):
 
 
 class TestVariablesInLinks:
-    def test_simple(self):
+    def test_variable(self):
         template_content = "((variable))"
         expected_rendered_markdown = "((variable))"
         html = BeautifulSoup(str(get_html_email_body(template_content, {})), "html.parser")
         rendered_markdown = html.get_text()
         assert rendered_markdown == expected_rendered_markdown
 
-    def test_less_simple(self):
+    def test_link_text_with_variable(self):
         template_content = "[link text with ((variable))](https://developer.mozilla.org/en-US/)"
         html = BeautifulSoup(str(get_html_email_body(template_content, {})), "html.parser")
         href = html.select("a")[0].get_attribute_list("href")[0]
@@ -57,7 +57,7 @@ class TestVariablesInLinks:
         assert href == "https://developer.mozilla.org/en-US/"
         assert link_text == "link text with ((variable))"
 
-    def test_less_simple_2(self):
+    def test_link_with_query_param(self):
         template_content = "[link with query param](https://developer.mozilla.org/en-US/search?q=asdf)"
         html = BeautifulSoup(str(get_html_email_body(template_content, {})), "html.parser")
         href = html.select("a")[0].get_attribute_list("href")[0]
@@ -65,7 +65,7 @@ class TestVariablesInLinks:
         assert href == "https://developer.mozilla.org/en-US/search?q=asdf"
         assert link_text == "link with query param"
 
-    def test_less_simple_3(self):
+    def test_link_with_var_as_url(self):
         # failing
         template_content = "[link with variable as url](((url_var)))"
         html = BeautifulSoup(str(get_html_email_body(template_content, {})), "html.parser")
@@ -75,7 +75,7 @@ class TestVariablesInLinks:
         assert link_text == "link with variable as url"
         assert href == "url_var"
 
-    def test_less_simple_4(self):
+    def test_link_with_var_in_url(self):
         # failing
         template_content = "[link with variable in url](((url_var))/en-US/)"
         html = BeautifulSoup(str(get_html_email_body(template_content, {})), "html.parser")
@@ -85,7 +85,7 @@ class TestVariablesInLinks:
         assert link_text == "link with variable in url"
         assert href == "url_var/en-US/"
 
-    def test_less_simple_5(self):
+    def test_link_with_var_and_query_param(self):
         # failing
         template_content = "[link with variable and query param](((url_var))/en-US/search?q=asdf)"
         html = BeautifulSoup(str(get_html_email_body(template_content, {})), "html.parser")


### PR DESCRIPTION
# Summary | Résumé

This PR:
- adds a bunch of tests to check that, when a variable is in a link url, the html we get back is well formatted
- adds a 2nd regex pattern to match variables inside the url portion of a markdown link
- adds a regex replace to remove the double brackets from these variables, if no values are passed in and we are just previewing the html. This prevents the html from becoming incorrect after the markdown is converted to html

## Related Issues | Cartes liées

* https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/614
* https://github.com/cds-snc/notification-planning/issues/783


# Test instructions | Instructions pour tester la modification

- open up notification-admin locally
- modify line 52 in pyproject.toml to read:
```
notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", branch = "fix/variable-in-link-bug"}
```
- rebuild your admin container and run the app
- create a template with a variable in a url link like this: `[link with variable and query param](((url_var))/en-US/search?q=asdf)`
- Verify that the template preview looks good
- send the template to yourself and verify the link works correctly in the email (you can set `url_var = https://developer.mozilla.org` for the example above).


# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.