### PR TITLE
Skip notification seeding when nothing to seed

### DIFF
--- a/notifications_utils/clients/redis/annual_limit.py
+++ b/notifications_utils/clients/redis/annual_limit.py
@@ -25,6 +25,8 @@ annual-limit: {
 
 from datetime import datetime
 
+from flask import current_app
+
 from notifications_utils.clients.redis.redis_client import RedisClient
 
 SMS_DELIVERED = "sms_delivered"
@@ -159,6 +161,12 @@ class RedisAnnualLimit:
                     "email_failed": int
                 }
         """
+        if not mapping or all(notification_count == 0 for notification_count in mapping.values()):
+            current_app.logger.info(
+                f"Skipping seeding of annual limit notifications for service {service_id}. No mapping provided, or mapping is empty indicating no notification to seed."
+            )
+            return
+
         self._redis_client.bulk_set_hash_fields(key=annual_limit_notifications_key(service_id), mapping=mapping)
 
     def was_seeded_today(self, service_id):

--- a/tests/test_annual_limit.py
+++ b/tests/test_annual_limit.py
@@ -211,6 +211,26 @@ def test_clear_annual_limit_statuses(mock_annual_limit_client, mocked_service_id
     assert all(value is None for value in statuses.values())
 
 
+@pytest.mark.parametrize(
+    "mapping",
+    [
+        {},
+        None,
+        {
+            "key": 0,
+            "key2": 0,
+            "key3": 0,
+        },
+    ],
+)
+def test_seed_annual_limit_notifications_skips_seeding_if_no_notifications_to_seed(
+    app, mock_annual_limit_client, mocked_service_id, mapping, mocker
+):
+    mock_annual_limit_client.seed_annual_limit_notifications(mocked_service_id, mapping)
+    mocked_set_hash_fields = mocker.patch.object(mock_annual_limit_client._redis_client, "bulk_set_hash_fields")
+    mocked_set_hash_fields.assert_not_called()
+
+
 @freeze_time("2024-10-25 12:00:00.000000")
 @pytest.mark.parametrize("seeded_at_value, expected_value", [(b"2024-10-25", True), (None, False)])
 def test_was_seeded_today(mock_annual_limit_client, seeded_at_value, expected_value, mocked_service_id, mocker):


### PR DESCRIPTION
# Summary | Résumé

This PR changes the annual limit client to skip the seeding of annual limit notification counts if there are no notifications to seed or their values are 0. This resolves an issue where `hmset` was called with an empty dict, causing the underlying pyRedis implementation to throw an exception.


## Related Issues | Cartes liées

* https://gcdigital.slack.com/archives/CNWA63606/p1736179889838109

# Test instructions | Instructions pour tester la modification

Tests pass

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.