### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.devcontainer/scripts/notify-dev-entrypoint.sh
+++ b/.devcontainer/scripts/notify-dev-entrypoint.sh
@@ -22,6 +22,9 @@ poetry completions zsh > ~/.zfunc/_poetry
 # Install dependencies
 poetry install
 
+# Set up git blame to ignore certain revisions e.g. sweeping code formatting changes.
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+
 # Install pre-commit hooks
 git config --global --add safe.directory /workspaces/notification-utils
 poetry run pre-commit install

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+##################################################################
+## This file lists commits that should be ignored by git blame. ##
+## e.g. Formatting commits, non-functional changes, etc.        ##
+##################################################################
+
+# Black formatter https://github.com/cds-snc/notification-utils/commit/321dda7eb7ead83b32413f1b6425b78c757c2404
+321dda7eb7ead83b32413f1b6425b78c757c2404
+# Subsequent Black formatter changes https://github.com/cds-snc/notification-utils/commit/98dbf4c5234239e761375402a87a17ee07acc0d0
+98dbf4c5234239e761375402a87a17ee07acc0d0
+# Ruff formatter https://github.com/cds-snc/notification-utils/commit/56c2f9ff16038e1c6eb63979d5166e08110d3ec9
+56c2f9ff16038e1c6eb63979d5166e08110d3ec9


### PR DESCRIPTION
# Summary | Résumé
This PR adds [`.git-blame-ignore-revs`](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view) to the project. This lets us to filter out specified commits when using git blame, e.g. bulk formatting and other changes that do not affect functionality.

To ignore a commit, just add the commit SHA to [.git-blame-ignore-revs](https://github.com/cds-snc/notification-utils/pull/351/files#diff-f247fbfbe928b907db42554d0b3006b28dd11c25a59be031abda73b11a2c934a)

# Test instructions | Instructions pour tester la modification
1. Open `.git-blame-ignore-revs` and open one of the links to an ignored commit.
2. Open a file that the ignored commit changed and run git blame.
3. Note that the ignored commits are not present and the commit previous is shown instead.

## After this PR is merged
- [ ] Repeat the above steps but open the file on the Github website and open the blame tool
- [ ] The excluded commits are not present on the web version
- [ ] Appending a `~` to the commit SHA in the URL shows the ignored commits