### PR TITLE
Edit Annual Limit client to add new data around year info

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -2,4 +2,4 @@ docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
 setuptools==75.6.0 # required for distutils in Python 3.12
-git+https://github.com/cds-snc/notifier-utils.git@53.1.2#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@53.2.0#egg=notifications-utils

--- a/notifications_utils/clients/redis/annual_limit.py
+++ b/notifications_utils/clients/redis/annual_limit.py
@@ -1,7 +1,7 @@
 """
 This module stores daily notification counts and annual limit statuses for a service in Redis using a hash structure:
 
-
+# TODO: Remove the first key once all services have been migrated to the new Redis structure
 annual-limit: {
     {service_id}: {
         notifications: {
@@ -16,6 +16,15 @@ annual-limit: {
             over_sms_limit: Datetime,
             over_email_limit: Datetime
             seeded_at: Datetime
+        },
+        notifications_v2: {
+            sms_delivered_today: int,
+            email_delivered_today: int,
+            sms_failed_today: int,
+            email_failed_today: int,
+            total_sms_fiscal_year_to_yesterday: int,
+            total_email_fiscal_year_to_yesterday: int,
+            seeded_at: Datetime
         }
     }
 }
@@ -29,12 +38,27 @@ from flask import current_app
 
 from notifications_utils.clients.redis.redis_client import RedisClient
 
+# TODO: Remove the first 4 keys once all services have been migrated to the new Redis structure
 SMS_DELIVERED = "sms_delivered"
 EMAIL_DELIVERED = "email_delivered"
 SMS_FAILED = "sms_failed"
 EMAIL_FAILED = "email_failed"
+SMS_DELIVERED_TODAY = "sms_delivered_today"
+EMAIL_DELIVERED_TODAY = "email_delivered_today"
+SMS_FAILED_TODAY = "sms_failed_today"
+EMAIL_FAILED_TODAY = "email_failed_today"
+TOTAL_SMS_FISCAL_YEAR_TO_YESTERDAY = "total_sms_fiscal_year_to_yesterday"
+TOTAL_EMAIL_FISCAL_YEAR_TO_YESTERDAY = "total_email_fiscal_year_to_yesterday"
 
 NOTIFICATION_FIELDS = [SMS_DELIVERED, EMAIL_DELIVERED, SMS_FAILED, EMAIL_FAILED]
+NOTIFICATION_FIELDS_V2 = [
+    SMS_DELIVERED_TODAY,
+    EMAIL_DELIVERED_TODAY,
+    SMS_FAILED_TODAY,
+    EMAIL_FAILED_TODAY,
+    TOTAL_SMS_FISCAL_YEAR_TO_YESTERDAY,
+    TOTAL_EMAIL_FISCAL_YEAR_TO_YESTERDAY,
+]
 
 NEAR_SMS_LIMIT = "near_sms_limit"
 NEAR_EMAIL_LIMIT = "near_email_limit"
@@ -45,11 +69,19 @@ SEEDED_AT = "seeded_at"
 STATUS_FIELDS = [NEAR_SMS_LIMIT, NEAR_EMAIL_LIMIT, OVER_SMS_LIMIT, OVER_EMAIL_LIMIT]
 
 
+# TODO: Remove this once all services have been migrated to the new Redis structure
 def annual_limit_notifications_key(service_id):
     """
     Generates the Redis hash key for storing daily metrics of a service.
     """
     return f"annual-limit:{service_id}:notifications"
+
+
+def annual_limit_notifications_v2_key(service_id):
+    """
+    Generates the Redis hash key for storing daily metrics of a service.
+    """
+    return f"annual-limit:{service_id}:notifications_v2"
 
 
 def annual_limit_status_key(service_id):
@@ -112,12 +144,21 @@ class RedisAnnualLimit:
             service_id (str): _description_
             field (str): _description_
         """
-        self._redis_client.increment_hash_value(annual_limit_notifications_key(service_id), field)
+        # TODO: Remove the else
+        if field in NOTIFICATION_FIELDS_V2:
+            self._redis_client.increment_hash_value(annual_limit_notifications_v2_key(service_id), field)
+        else:
+            self._redis_client.increment_hash_value(annual_limit_notifications_key(service_id), field)
 
     def get_notification_count(self, service_id: str, field: str):
         """
-        Retrieves the specified daily notification count for a service. (e.g. SMS_DELIVERED, EMAIL_FAILED, etc.)
+        Retrieves the specified daily notification count for a service. (e.g. SMS_DELIVERED, EMAIL_FAILED, SMS_DELIVERED_TODAY etc.)
         """
+        count = self._redis_client.get_hash_field(annual_limit_notifications_v2_key(service_id), field)
+        if count:
+            return int(count.decode("utf-8"))
+        # TODO: Remove this once all services have been migrated to the new Redis structure
+        # TODO: Change the above to return 0 if count is None
         count = self._redis_client.get_hash_field(annual_limit_notifications_key(service_id), field)
         return 0 if not count else int(count.decode("utf-8"))
 
@@ -125,6 +166,18 @@ class RedisAnnualLimit:
         """
         Retrieves all daily notification metrics for a service.
         """
+        if self._redis_client.redis_store.exists(annual_limit_notifications_v2_key(service_id)):
+            all_keys = self._redis_client.get_all_from_hash(annual_limit_notifications_v2_key(service_id))
+            # remove the seeded_at key from the list of keys
+            seeded_at_byte = bytes(SEEDED_AT, "utf-8")
+            if seeded_at_byte in all_keys:
+                del all_keys[seeded_at_byte]
+            return prepare_byte_dict(
+                all_keys,
+                int,
+                NOTIFICATION_FIELDS_V2,
+            )
+        # TODO: Remove this once all services have been migrated to the new Redis structure
         return prepare_byte_dict(
             self._redis_client.get_all_from_hash(annual_limit_notifications_key(service_id)), int, NOTIFICATION_FIELDS
         )
@@ -137,16 +190,22 @@ class RedisAnnualLimit:
 
         """
         hashes = (
+            annual_limit_notifications_v2_key("*")
+            if not service_ids
+            else [annual_limit_notifications_v2_key(service_id) for service_id in service_ids]
+        )
+        self._redis_client.delete_hash_fields(hashes=hashes, fields=NOTIFICATION_FIELDS_V2)
+        # TODO: Remove the else once all services have been migrated to the new Redis structure
+        hashes = (
             annual_limit_notifications_key("*")
             if not service_ids
             else [annual_limit_notifications_key(service_id) for service_id in service_ids]
         )
-
         self._redis_client.delete_hash_fields(hashes=hashes, fields=NOTIFICATION_FIELDS)
 
     def seed_annual_limit_notifications(self, service_id: str, mapping: dict):
         """Seeds annual limit notifications for a service.
-
+        # TODO: Update the docstring once all services have been migrated to the new Redis structure
         Args:
             service_id (str): Service to seed annual limit notifications for.
             mapping (dict): A dict used to map notification counts to their respective fields formatted as follows
@@ -158,7 +217,16 @@ class RedisAnnualLimit:
                     "sms_delivered": int,
                     "email_delivered": int,
                     "sms_failed": int,
-                    "email_failed": int
+                    "email_failed": int,
+                }
+            as we added notifications_v2, the mapping can also be:
+                {
+                    "sms_delivered_today": int,
+                    "email_delivered_today": int,
+                    "sms_failed_today": int,
+                    "email_failed_today": int,
+                    "total_sms_fiscal_year_to_yesterday": int,
+                    "total_email_fiscal_year_to_yesterday": int,
                 }
         """
         if not mapping or all(notification_count == 0 for notification_count in mapping.values()):
@@ -166,24 +234,34 @@ class RedisAnnualLimit:
                 f"Skipping seeding of annual limit notifications for service {service_id}. No mapping provided, or mapping is empty indicating no notification to seed."
             )
             return
-
+        # TODO: Remove the else once all services have been migrated to the new Redis structure
+        self.set_seeded_at(service_id)
+        if set(mapping.keys()) == set(NOTIFICATION_FIELDS_V2):
+            self._redis_client.bulk_set_hash_fields(key=annual_limit_notifications_v2_key(service_id), mapping=mapping)
         self._redis_client.bulk_set_hash_fields(key=annual_limit_notifications_key(service_id), mapping=mapping)
 
     def was_seeded_today(self, service_id):
         last_seeded_time = self.get_seeded_at(service_id)
         return last_seeded_time == datetime.utcnow().strftime("%Y-%m-%d") if last_seeded_time else False
 
-    def get_seeded_at(self, service_id: str):
-        seeded_at = self._redis_client.get_hash_field(annual_limit_status_key(service_id), SEEDED_AT)
+    def get_seeded_at(self, service_id: str, key=None):
+        seeded_at = self._redis_client.get_hash_field(annual_limit_notifications_v2_key(service_id), SEEDED_AT)
         return seeded_at and seeded_at.decode("utf-8")
 
     def set_seeded_at(self, service_id):
+        # We are now setting the seeded value for notifications_v2
+        self._redis_client.set_hash_value(
+            annual_limit_notifications_v2_key(service_id), SEEDED_AT, datetime.utcnow().strftime("%Y-%m-%d")
+        )
+        # TODO: Remove the below once all services have been migrated to the new Redis structure
+        # Setting the seeded at in status for backward compatibility
         self._redis_client.set_hash_value(annual_limit_status_key(service_id), SEEDED_AT, datetime.utcnow().strftime("%Y-%m-%d"))
 
     def clear_notification_counts(self, service_id: str):
         """
         Clears all daily notification metrics for a service.
         """
+        self._redis_client.expire(annual_limit_notifications_v2_key(service_id), -1)
         self._redis_client.expire(annual_limit_notifications_key(service_id), -1)
 
     def set_annual_limit_status(self, service_id: str, field: str, value: datetime):
@@ -211,6 +289,8 @@ class RedisAnnualLimit:
         Returns:
             str | None: The date the status was set, or None if the status has not been set
         """
+        if field == "seeded_at":
+            return self.get_seeded_at(service_id)
         response = self._redis_client.get_hash_field(annual_limit_status_key(service_id), field)
         return response and response.decode("utf-8")
 
@@ -230,18 +310,26 @@ class RedisAnnualLimit:
 
     # Helper methods for daily metrics
     def increment_sms_delivered(self, service_id: str):
+        self.increment_notification_count(service_id, SMS_DELIVERED_TODAY)
+        # TODO: remove the below line
         self.increment_notification_count(service_id, SMS_DELIVERED)
 
     def increment_sms_failed(self, service_id: str):
+        self.increment_notification_count(service_id, SMS_FAILED_TODAY)
+        # TODO: remove the below line
         self.increment_notification_count(service_id, SMS_FAILED)
 
     def increment_email_delivered(self, service_id: str):
+        self.increment_notification_count(service_id, EMAIL_DELIVERED_TODAY)
+        # TODO: remove the below line
         self.increment_notification_count(service_id, EMAIL_DELIVERED)
 
     def increment_email_failed(self, service_id: str):
+        self.increment_notification_count(service_id, EMAIL_FAILED_TODAY)
+        # TODO: remove the below line
         self.increment_notification_count(service_id, EMAIL_FAILED)
 
-    # Helper methods for annual limits
+    # Helper methods for annual limits statuses
     def set_nearing_sms_limit(self, service_id: str):
         self.set_annual_limit_status(service_id, NEAR_SMS_LIMIT, datetime.utcnow())
 
@@ -283,9 +371,12 @@ class RedisAnnualLimit:
             service_ids (Optional): A list of service_ids to clear annual limit hashes for. Clears all services if None.
         """
         if not service_ids:
+            self._redis_client.delete_cache_keys_by_pattern(annual_limit_notifications_v2_key("*"))
+            # TODO: Remove the line below
             self._redis_client.delete_cache_keys_by_pattern(annual_limit_notifications_key("*"))
             self._redis_client.delete_cache_keys_by_pattern(annual_limit_status_key("*"))
         else:
             for service_id in service_ids:
+                self._redis_client.delete(annual_limit_notifications_v2_key(service_id))
                 self._redis_client.delete(annual_limit_notifications_key(service_id))
                 self._redis_client.delete(annual_limit_status_key(service_id))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "53.1.2"
+version = "53.2.0"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"


### PR DESCRIPTION
# Summary | Résumé

Added year to date information in the annual limit client

```
        notifications_v2: {
            sms_delivered_today: int,
            email_delivered_today: int,
            sms_failed_today: int,
            email_failed_today: int,
            total_sms_fiscal_year_to_yesterday: int,
            total_email_fiscal_year_to_yesterday: int,
        }
```
Code is written to be backwards compatible

## Related Issues | Cartes liées
https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/gh/cds-snc/notification-planning/1767

# Test instructions | Instructions pour tester la modification

_TODO: Fill in test instructions for the reviewer._

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.