### PR TITLE
Make poetry venv path static

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,7 @@
 FROM mcr.microsoft.com/vscode/devcontainers/python:3.12
 
 ENV POETRY_VERSION="1.7.1"
+ENV POETRY_VENV_PATH="/home/vscode/.venv/workspace"
 
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils 2>&1 \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,8 @@
 				"charliermarsh.ruff",
 			],
 			"settings": {
-				"python.pythonPath": "/usr/local/bin/python",
+				"python.defaultInterpreterPath": "/home/vscode/.venv/workspace/bin/python",
+				"python.venvPath": "/home/vscode/.venv",
 				"ruff.lint.ignore": ["F401"],
 				"ruff.lint.run": "onSave",
 				"ruff.organizeImports": false,

--- a/.devcontainer/scripts/notify-dev-entrypoint.sh
+++ b/.devcontainer/scripts/notify-dev-entrypoint.sh
@@ -14,10 +14,21 @@ echo -e "autoload -Uz compinit && compinit"
 pip install poetry==${POETRY_VERSION} poetry-plugin-sort \
   && poetry --version
 
+
+# Disable poetry auto-venv creation
+poetry config virtualenvs.create false
+
 # Initialize poetry autocompletions
 mkdir ~/.zfunc
 touch ~/.zfunc/_poetry
 poetry completions zsh > ~/.zfunc/_poetry
+
+# Manually create and activate a virtual environment with a static path
+python -m venv "${POETRY_VENV_PATH}"
+source "${POETRY_VENV_PATH}/bin/activate"
+
+# Ensure newly created shells activate the poetry venv
+echo "source ${POETRY_VENV_PATH}/bin/activate" >> ~/.zshrc
 
 # Install dependencies
 poetry install


### PR DESCRIPTION
# Summary | Résumé

Similar to the work done in Admin and [API](https://github.com/cds-snc/notification-api/pull/2460) this PR makes our poetry dev container venv paths static so vscode consistently picks up and automatically uses the correct venv when switching between or rebuilding containers.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-api/pull/2460
* https://github.com/cds-snc/notification-admin/pull/2076

# Test instructions | Instructions pour tester la modification
1. In vscode - `ctrl + shift + p` and select `Python: clear workspace interpreter setting`
2. Rebuild the dev container 
3. Once the container is built, you may need to select the interpreter again
4. Open a new terminal / shell
5. Note that the virtual environment is automatically activated

## Ensure venv path is maintained across separate container builds
1. Check out [this admin PR](https://github.com/cds-snc/notification-admin/pull/2076)
2. Rebuild the container **without cache**
3. Note that the interpreter is automatically selected
4. Open a terminal, note that the correct venv is automatically activated

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.