### PR TITLE
Set seeding_at only after the seeded data exists in Redis

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -2,4 +2,4 @@ docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
 setuptools==75.6.0 # required for distutils in Python 3.12
-git+https://github.com/cds-snc/notifier-utils.git@53.2.0#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@53.2.1#egg=notifications-utils

--- a/notifications_utils/clients/redis/annual_limit.py
+++ b/notifications_utils/clients/redis/annual_limit.py
@@ -244,7 +244,7 @@ class RedisAnnualLimit:
             current_app.logger.warning(f"Missing V2 fields when seeding annual limit for service {service_id}: {missing_fields}")
 
         # Store V2 fields
-        self._redis_client.bulk_set_hash_fields(key=annual_limit_notifications_v2_key(service_id), mapping=v2_mapping)
+        v2_result = self._redis_client.bulk_set_hash_fields(key=annual_limit_notifications_v2_key(service_id), mapping=v2_mapping)
 
         # Create a legacy mapping from either original legacy keys or mapped from V2 keys
         legacy_mapping = {}
@@ -269,7 +269,8 @@ class RedisAnnualLimit:
             self._redis_client.bulk_set_hash_fields(key=annual_limit_notifications_key(service_id), mapping=legacy_mapping)
 
         # Only after successful storage, set the seeded flag
-        self.set_seeded_at(service_id)
+        if v2_result:
+            self.set_seeded_at(service_id)
 
     def was_seeded_today(self, service_id):
         last_seeded_time = self.get_seeded_at(service_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "53.2.0"
+version = "53.2.1"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"


### PR DESCRIPTION
# Summary | Résumé

- Added some logging to help us catch when fields are missing in the annual_limit_notifications_v2 key
- Reworked backwards compatibility, previously the method expected ALL v2 keys to be present in order to update the seeded data.
- Set the seeding_at key only after the seeded data has been written to Redis, making the process more atomic in nature.

## Related Issues | Cartes liées

* https://gcdigital.slack.com/archives/CV38DBNVA/p1747062605779569?thread_ts=1747062585.422499&cid=CV38DBNVA

# Test instructions | Instructions pour tester la modification

* CI is passing
* Once in staging, we need to verify that all services have their `total_email_fiscal_year_to_yesterday` keys populated correctly when a day rolls over.


# Release Instructions | Instructions pour le déploiement



# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.