### PR TITLE
feat(logging): add timing information to additional logging details

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -2,4 +2,4 @@ docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
 setuptools==75.6.0 # required for distutils in Python 3.12
-git+https://github.com/cds-snc/notifier-utils.git@53.2.2#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@53.2.3#egg=notifications-utils

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -248,7 +248,7 @@ def _getAdditionalLoggingDetails():
         # Add timing information if available
         if hasattr(g, "start"):
             time_taken = (monotonic() - g.start) * 1000  # Convert to milliseconds
-            additionalDetails += f"time_taken: '{time_taken:.2f}ms' "
+            additionalDetails += f"time_taken: {time_taken:.2f}ms "
 
         try:
             # log request fields if they are present

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -245,6 +245,11 @@ def _getAdditionalLoggingDetails():
         bodyFields = ("template_id", "service_id", "notification_id")
         additionalDetails = " [Request details: "
 
+        # Add timing information if available
+        if hasattr(g, "start"):
+            time_taken = (monotonic() - g.start) * 1000  # Convert to milliseconds
+            additionalDetails += f"time_taken: '{time_taken:.2f}ms' "
+
         try:
             # log request fields if they are present
             for field in requestFields:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "53.2.2"
+version = "53.2.3"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -191,6 +191,11 @@ def test_logger_adds_extra_context_details(app, mocker, debugconfig, testcases):
     def createApp(app):
         app.debug = debugconfig
 
+        @app.before_request
+        def record_request_details():
+            g.start = monotonic()  # Add this line
+            g.endpoint = request.endpoint
+
         @app.route("/info", methods=["POST"])
         def info():
             app.logger.info("info")
@@ -242,6 +247,8 @@ def test_logger_adds_extra_context_details(app, mocker, debugconfig, testcases):
             assert "template_id" in errorMessage
             # ensure request data (endpoint) is shown
             assert "endpoint" in errorMessage
+            # ensure time_taken is shown
+            assert "time_taken" in errorMessage
 
 
 @pytest.mark.parametrize("debugconfig", [True, False])


### PR DESCRIPTION
# Summary | Résumé

Add `time_taken` to logging that  makes use of information already available in a flask request.  This will apply to logs in both admin and API.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/1917

# Test instructions | Instructions pour tester la modification

## API
* Make a request in API
* Look at the log output
* [ ] Ensure `time_taken` is in the log 

## ADMIN
* Make a request in API
* Look at the log output
* [ ] Ensure `time_taken` is in the log 

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.