### PR TITLE
Fix nested list padding attempt 3

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -2,4 +2,4 @@ docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
 setuptools==75.6.0 # required for distutils in Python 3.12
-git+https://github.com/cds-snc/notifier-utils.git@53.2.5#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@53.2.6#egg=notifications-utils

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -7,6 +7,7 @@ from typing import List
 import bleach
 import mistune
 import smartypants
+from bs4 import BeautifulSoup
 from flask import Markup
 
 from notifications_utils.sanitise_text import SanitiseSMS
@@ -702,45 +703,20 @@ def remove_nested_list_padding(_content: str) -> str:
     padding. This function finds table elements that contain lists and are
     nested inside list items, and removes their padding.
     """
-    # Pattern to match the table element we want to replace
-    table_pattern = '<table role="presentation" style="padding: 0 0 20px 0;">'
-    replacement = '<table role="presentation" style="padding: 0;">'
+    # Use BeautifulSoup to parse and modify HTML
+    soup = BeautifulSoup(_content, "html.parser")
 
-    result = []
-    i = 0
-    li_depth = 0  # Track nesting depth of <li> elements
+    # Find all table elements with the specific padding style
+    tables = soup.find_all(
+        "table", attrs={"role": "presentation", "style": lambda value: value and "padding: 0 0 20px 0" in value}
+    )
 
-    while i < len(_content):
-        # Check if we're at the start of an <li> tag
-        if _content[i : i + 3] == "<li":
-            # Find the end of this <li> tag
-            tag_end = _content.find(">", i)
-            if tag_end != -1:
-                li_depth += 1
-                result.append(_content[i : tag_end + 1])
-                i = tag_end + 1
-                continue
+    for table in tables:
+        # Check if this table is nested inside an <li> element
+        if table.find_parent("li"):
+            # Replace the padding style
+            current_style = table.get("style", "")
+            new_style = current_style.replace("padding: 0 0 20px 0", "padding: 0")
+            table["style"] = new_style
 
-        # Check if we're at a </li> tag
-        elif _content[i : i + 5] == "</li>":
-            li_depth = max(0, li_depth - 1)
-            result.append(_content[i : i + 5])
-            i += 5
-            continue
-
-        # Check if we're at our target table pattern
-        elif _content[i : i + len(table_pattern)] == table_pattern:
-            if li_depth > 0:
-                # We're inside an <li> element, so replace the padding
-                result.append(replacement)
-            else:
-                # We're not inside an <li> element, so keep original
-                result.append(table_pattern)
-            i += len(table_pattern)
-            continue
-
-        # Otherwise, just add the current character
-        result.append(_content[i])
-        i += 1
-
-    return "".join(result)
+    return str(soup)

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -7,7 +7,6 @@ from typing import List
 import bleach
 import mistune
 import smartypants
-from bs4 import BeautifulSoup
 from flask import Markup
 
 from notifications_utils.sanitise_text import SanitiseSMS
@@ -703,28 +702,45 @@ def remove_nested_list_padding(_content: str) -> str:
     padding. This function finds table elements that contain lists and are
     nested inside list items, and removes their padding.
     """
-    if not _content.strip():
-        return _content
+    # Pattern to match the table element we want to replace
+    table_pattern = '<table role="presentation" style="padding: 0 0 20px 0;">'
+    replacement = '<table role="presentation" style="padding: 0;">'
 
-    # Use BeautifulSoup to parse and modify the DOM structure
-    try:
-        soup = BeautifulSoup(_content, "html.parser")
-    except Exception:
-        # Fallback to original content if parsing fails
-        return _content
+    result = []
+    i = 0
+    li_depth = 0  # Track nesting depth of <li> elements
 
-    # Find all table elements with the specific padding style that are nested inside <li> elements
-    target_tables = soup.find_all(
-        "table", {"role": "presentation", "style": lambda style: style and "padding: 0 0 20px 0;" in style}
-    )
+    while i < len(_content):
+        # Check if we're at the start of an <li> tag
+        if _content[i : i + 3] == "<li":
+            # Find the end of this <li> tag
+            tag_end = _content.find(">", i)
+            if tag_end != -1:
+                li_depth += 1
+                result.append(_content[i : tag_end + 1])
+                i = tag_end + 1
+                continue
 
-    # For each table, check if it's nested inside an <li> element
-    for table in target_tables:
-        if table.find_parent("li"):
-            # Modify the style attribute
-            current_style = table.get("style", "")
-            new_style = current_style.replace("padding: 0 0 20px 0;", "padding: 0;")
-            table["style"] = new_style
+        # Check if we're at a </li> tag
+        elif _content[i : i + 5] == "</li>":
+            li_depth = max(0, li_depth - 1)
+            result.append(_content[i : i + 5])
+            i += 5
+            continue
 
-    # Return the modified HTML
-    return str(soup)
+        # Check if we're at our target table pattern
+        elif _content[i : i + len(table_pattern)] == table_pattern:
+            if li_depth > 0:
+                # We're inside an <li> element, so replace the padding
+                result.append(replacement)
+            else:
+                # We're not inside an <li> element, so keep original
+                result.append(table_pattern)
+            i += len(table_pattern)
+            continue
+
+        # Otherwise, just add the current character
+        result.append(_content[i])
+        i += 1
+
+    return "".join(result)

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -694,3 +694,53 @@ def remove_tags(_content: str, *tags) -> str:
     for tag in tags:
         content = re.compile(tag).sub("", content)
     return content
+
+
+def remove_nested_list_padding(_content: str) -> str:
+    """Remove bottom padding from nested lists.
+    Lists that are nested inside <li> elements should not have the 20px bottom
+    padding. This function finds table elements that contain lists and are
+    nested inside list items, and removes their padding.
+    """
+    # Pattern to match the table element we want to replace
+    table_pattern = '<table role="presentation" style="padding: 0 0 20px 0;">'
+    replacement = '<table role="presentation" style="padding: 0;">'
+
+    result = []
+    i = 0
+    li_depth = 0  # Track nesting depth of <li> elements
+
+    while i < len(_content):
+        # Check if we're at the start of an <li> tag
+        if _content[i : i + 3] == "<li":
+            # Find the end of this <li> tag
+            tag_end = _content.find(">", i)
+            if tag_end != -1:
+                li_depth += 1
+                result.append(_content[i : tag_end + 1])
+                i = tag_end + 1
+                continue
+
+        # Check if we're at a </li> tag
+        elif _content[i : i + 5] == "</li>":
+            li_depth = max(0, li_depth - 1)
+            result.append(_content[i : i + 5])
+            i += 5
+            continue
+
+        # Check if we're at our target table pattern
+        elif _content[i : i + len(table_pattern)] == table_pattern:
+            if li_depth > 0:
+                # We're inside an <li> element, so replace the padding
+                result.append(replacement)
+            else:
+                # We're not inside an <li> element, so keep original
+                result.append(table_pattern)
+            i += len(table_pattern)
+            continue
+
+        # Otherwise, just add the current character
+        result.append(_content[i])
+        i += 1
+
+    return "".join(result)

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -7,7 +7,6 @@ from typing import List
 import bleach
 import mistune
 import smartypants
-from bs4 import BeautifulSoup
 from flask import Markup
 
 from notifications_utils.sanitise_text import SanitiseSMS
@@ -703,20 +702,45 @@ def remove_nested_list_padding(_content: str) -> str:
     padding. This function finds table elements that contain lists and are
     nested inside list items, and removes their padding.
     """
-    # Use BeautifulSoup to parse and modify HTML
-    soup = BeautifulSoup(_content, "html.parser")
+    # Pattern to match the table element we want to replace
+    table_pattern = '<table role="presentation" style="padding: 0 0 20px 0;">'
+    replacement = '<table role="presentation" style="padding: 0;">'
 
-    # Find all table elements with the specific padding style
-    tables = soup.find_all(
-        "table", attrs={"role": "presentation", "style": lambda value: value and "padding: 0 0 20px 0" in value}
-    )
+    result = []
+    i = 0
+    li_depth = 0  # Track nesting depth of <li> elements
 
-    for table in tables:
-        # Check if this table is nested inside an <li> element
-        if table.find_parent("li"):
-            # Replace the padding style
-            current_style = table.get("style", "")
-            new_style = current_style.replace("padding: 0 0 20px 0", "padding: 0")
-            table["style"] = new_style
+    while i < len(_content):
+        # Check if we're at the start of an <li> tag
+        if _content[i : i + 3] == "<li":
+            # Find the end of this <li> tag
+            tag_end = _content.find(">", i)
+            if tag_end != -1:
+                li_depth += 1
+                result.append(_content[i : tag_end + 1])
+                i = tag_end + 1
+                continue
 
-    return str(soup)
+        # Check if we're at a </li> tag
+        elif _content[i : i + 5] == "</li>":
+            li_depth = max(0, li_depth - 1)
+            result.append(_content[i : i + 5])
+            i += 5
+            continue
+
+        # Check if we're at our target table pattern
+        elif _content[i : i + len(table_pattern)] == table_pattern:
+            if li_depth > 0:
+                # We're inside an <li> element, so replace the padding
+                result.append(replacement)
+            else:
+                # We're not inside an <li> element, so keep original
+                result.append(table_pattern)
+            i += len(table_pattern)
+            continue
+
+        # Otherwise, just add the current character
+        result.append(_content[i])
+        i += 1
+
+    return "".join(result)

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -30,6 +30,7 @@ from notifications_utils.formatters import (
     notify_plain_text_email_markdown,
     remove_empty_lines,
     remove_language_divs,
+    remove_nested_list_padding,
     remove_rtl_divs,
     remove_smart_quotes_from_email_addresses,
     remove_whitespace_before_punctuation,
@@ -826,6 +827,7 @@ def get_html_email_body(template_content, template_values, redact_missing_person
         .then(escape_lang_tags)
         .then(escape_rtl_tags)
         .then(notify_email_markdown)
+        .then(remove_nested_list_padding)
         .then(add_language_divs)
         .then(add_rtl_divs)
         .then(do_nice_typography)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "53.2.5"
+version = "53.2.6"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -15,6 +15,7 @@ from notifications_utils.formatters import (
     notify_letter_preview_markdown,
     notify_plain_text_email_markdown,
     remove_language_divs,
+    remove_nested_list_padding,
     remove_smart_quotes_from_email_addresses,
     remove_whitespace_before_punctuation,
     replace_hyphens_with_en_dashes,
@@ -1136,3 +1137,180 @@ bonjour
             testString
             == f'<div lang="fr-ca">{EMAIL_P_OPEN_TAG}Le français suis l\'anglais{EMAIL_P_CLOSE_TAG}</div><div lang="en-ca">{EMAIL_P_OPEN_TAG}hi{EMAIL_P_CLOSE_TAG}<div lang="fr-ca">{EMAIL_P_OPEN_TAG}NESTED!{EMAIL_P_CLOSE_TAG}</div></div><div lang="fr-ca">{EMAIL_P_OPEN_TAG}bonjour{EMAIL_P_CLOSE_TAG}</div>'  # noqa
         )
+
+
+class TestRemoveNestedListPadding:
+    @pytest.mark.parametrize(
+        "input_html, expected_output",
+        [
+            # Basic case: nested list inside li should have padding removed
+            (
+                '<li>Item 1<table role="presentation" style="padding: 0 0 20px 0;"><tr><td><ul><li>Nested item</li></ul></td></tr></table></li>',
+                '<li>Item 1<table role="presentation" style="padding: 0;"><tr><td><ul><li>Nested item</li></ul></td></tr></table></li>',
+            ),
+            # Multiple nested lists in same li
+            (
+                '<li>Item 1<table role="presentation" style="padding: 0 0 20px 0;"><tr><td><ul><li>Nested 1</li></ul></td></tr></table>Some text<table role="presentation" style="padding: 0 0 20px 0;"><tr><td><ol><li>Nested 2</li></ol></td></tr></table></li>',
+                '<li>Item 1<table role="presentation" style="padding: 0;"><tr><td><ul><li>Nested 1</li></ul></td></tr></table>Some text<table role="presentation" style="padding: 0;"><tr><td><ol><li>Nested 2</li></ol></td></tr></table></li>',
+            ),
+            # Multiple list items with nested lists
+            (
+                '<ul><li>Item 1<table role="presentation" style="padding: 0 0 20px 0;"><tr><td><ul><li>Nested</li></ul></td></tr></table></li><li>Item 2<table role="presentation" style="padding: 0 0 20px 0;"><tr><td><ol><li>Another nested</li></ol></td></tr></table></li></ul>',
+                '<ul><li>Item 1<table role="presentation" style="padding: 0;"><tr><td><ul><li>Nested</li></ul></td></tr></table></li><li>Item 2<table role="presentation" style="padding: 0;"><tr><td><ol><li>Another nested</li></ol></td></tr></table></li></ul>',
+            ),
+            # Non-nested lists should keep their padding (tables not inside li)
+            (
+                '<div><table role="presentation" style="padding: 0 0 20px 0;"><tr><td><ul><li>Not nested</li></ul></td></tr></table></div>',
+                '<div><table role="presentation" style="padding: 0 0 20px 0;"><tr><td><ul><li>Not nested</li></ul></td></tr></table></div>',
+            ),
+            # Li with attributes should work
+            (
+                '<li class="item" style="color: red;">Item<table role="presentation" style="padding: 0 0 20px 0;"><tr><td><ul><li>Nested</li></ul></td></tr></table></li>',
+                '<li class="item" style="color: red;">Item<table role="presentation" style="padding: 0;"><tr><td><ul><li>Nested</li></ul></td></tr></table></li>',
+            ),
+            # Complex nested content with line breaks and whitespace
+            (
+                """<li>
+                    Item with content
+                    <table role="presentation" style="padding: 0 0 20px 0;">
+                        <tr>
+                            <td>
+                                <ul>
+                                    <li>Nested item 1</li>
+                                    <li>Nested item 2</li>
+                                </ul>
+                            </td>
+                        </tr>
+                    </table>
+                    More content
+                </li>""",
+                """<li>
+                    Item with content
+                    <table role="presentation" style="padding: 0;">
+                        <tr>
+                            <td>
+                                <ul>
+                                    <li>Nested item 1</li>
+                                    <li>Nested item 2</li>
+                                </ul>
+                            </td>
+                        </tr>
+                    </table>
+                    More content
+                </li>""",
+            ),
+            # Empty string should return empty string
+            ("", ""),
+            # Content without any lists should be unchanged
+            (
+                "<div><p>Some paragraph</p><span>Some text</span></div>",
+                "<div><p>Some paragraph</p><span>Some text</span></div>",
+            ),
+            # Tables with different padding should not be affected
+            (
+                '<li>Item<table role="presentation" style="padding: 10px 0 20px 0;"><tr><td><ul><li>Different padding</li></ul></td></tr></table></li>',
+                '<li>Item<table role="presentation" style="padding: 10px 0 20px 0;"><tr><td><ul><li>Different padding</li></ul></td></tr></table></li>',
+            ),
+            # Tables without role="presentation" should not be affected
+            (
+                '<li>Item<table style="padding: 0 0 20px 0;"><tr><td><ul><li>No role</li></ul></td></tr></table></li>',
+                '<li>Item<table style="padding: 0 0 20px 0;"><tr><td><ul><li>No role</li></ul></td></tr></table></li>',
+            ),
+        ],
+    )
+    def test_remove_nested_list_padding(self, input_html, expected_output):
+        """Test that remove_nested_list_padding correctly removes padding from nested lists."""
+        assert remove_nested_list_padding(input_html) == expected_output
+
+    def test_remove_nested_list_padding_with_real_email_html(self):
+        """Test with realistic HTML that would be generated by the email formatter."""
+        # This is the kind of HTML that would be generated for a nested list in an email
+        input_html = (
+            '<table role="presentation" style="padding: 0 0 20px 0;">'
+            "<tr>"
+            '<td style="font-family: Helvetica, Arial, sans-serif;">'
+            '<ul style="margin: 0; padding: 0; list-style-type: disc; margin-inline-start: 20px;">'
+            '<li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">'
+            "Top level item"
+            '<table role="presentation" style="padding: 0 0 20px 0;">'
+            "<tr>"
+            '<td style="font-family: Helvetica, Arial, sans-serif;">'
+            '<ul style="margin: 0; padding: 0; list-style-type: disc; margin-inline-start: 20px;">'
+            '<li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Nested item 1</li>'
+            '<li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Nested item 2</li>'
+            "</ul>"
+            "</td>"
+            "</tr>"
+            "</table>"
+            "</li>"
+            '<li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Another top level item</li>'
+            "</ul>"
+            "</td>"
+            "</tr>"
+            "</table>"
+        )
+
+        expected_output = (
+            '<table role="presentation" style="padding: 0 0 20px 0;">'
+            "<tr>"
+            '<td style="font-family: Helvetica, Arial, sans-serif;">'
+            '<ul style="margin: 0; padding: 0; list-style-type: disc; margin-inline-start: 20px;">'
+            '<li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">'
+            "Top level item"
+            '<table role="presentation" style="padding: 0;">'
+            "<tr>"
+            '<td style="font-family: Helvetica, Arial, sans-serif;">'
+            '<ul style="margin: 0; padding: 0; list-style-type: disc; margin-inline-start: 20px;">'
+            '<li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Nested item 1</li>'
+            '<li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Nested item 2</li>'
+            "</ul>"
+            "</td>"
+            "</tr>"
+            "</table>"
+            "</li>"
+            '<li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Another top level item</li>'
+            "</ul>"
+            "</td>"
+            "</tr>"
+            "</table>"
+        )
+
+        assert remove_nested_list_padding(input_html) == expected_output
+
+    def test_remove_nested_list_padding_preserves_other_content(self):
+        """Test that the function doesn't affect unrelated content."""
+        input_html = (
+            "<div>"
+            "<p>Some paragraph before</p>"
+            "<ul>"
+            "<li>Item 1"
+            '<table role="presentation" style="padding: 0 0 20px 0;">'
+            "<tr><td><ul><li>Nested item</li></ul></td></tr>"
+            "</table>"
+            "</li>"
+            "</ul>"
+            "<p>Some paragraph after</p>"
+            '<table role="presentation" style="padding: 0 0 20px 0;">'
+            "<tr><td>This should keep padding - not nested in li</td></tr>"
+            "</table>"
+            "</div>"
+        )
+
+        expected_output = (
+            "<div>"
+            "<p>Some paragraph before</p>"
+            "<ul>"
+            "<li>Item 1"
+            '<table role="presentation" style="padding: 0;">'
+            "<tr><td><ul><li>Nested item</li></ul></td></tr>"
+            "</table>"
+            "</li>"
+            "</ul>"
+            "<p>Some paragraph after</p>"
+            '<table role="presentation" style="padding: 0 0 20px 0;">'
+            "<tr><td>This should keep padding - not nested in li</td></tr>"
+            "</table>"
+            "</div>"
+        )
+
+        assert remove_nested_list_padding(input_html) == expected_output

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1184,20 +1184,7 @@ class TestRemoveNestedListPadding:
                     </table>
                     More content
                 </li>""",
-                """<li>
-                    Item with content
-                    <table role="presentation" style="padding: 0;">
-                        <tr>
-                            <td>
-                                <ul>
-                                    <li>Nested item 1</li>
-                                    <li>Nested item 2</li>
-                                </ul>
-                            </td>
-                        </tr>
-                    </table>
-                    More content
-                </li>""",
+                '<li>\n                    Item with content\n                    <table role="presentation" style="padding: 0;">\n<tr>\n<td>\n<ul>\n<li>Nested item 1</li>\n<li>Nested item 2</li>\n</ul>\n</td>\n</tr>\n</table>\n                    More content\n                </li>',
             ),
             # Empty string should return empty string
             ("", ""),
@@ -1250,30 +1237,7 @@ class TestRemoveNestedListPadding:
             "</table>"
         )
 
-        expected_output = (
-            '<table role="presentation" style="padding: 0 0 20px 0;">'
-            "<tr>"
-            '<td style="font-family: Helvetica, Arial, sans-serif;">'
-            '<ul style="margin: 0; padding: 0; list-style-type: disc; margin-inline-start: 20px;">'
-            '<li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">'
-            "Top level item"
-            '<table role="presentation" style="padding: 0;">'
-            "<tr>"
-            '<td style="font-family: Helvetica, Arial, sans-serif;">'
-            '<ul style="margin: 0; padding: 0; list-style-type: disc; margin-inline-start: 20px;">'
-            '<li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Nested item 1</li>'
-            '<li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Nested item 2</li>'
-            "</ul>"
-            "</td>"
-            "</tr>"
-            "</table>"
-            "</li>"
-            '<li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Another top level item</li>'
-            "</ul>"
-            "</td>"
-            "</tr>"
-            "</table>"
-        )
+        expected_output = '<table role="presentation" style="padding: 0 0 20px 0;"><tr><td style="font-family: Helvetica, Arial, sans-serif;"><ul style="margin: 0; padding: 0; list-style-type: disc; margin-inline-start: 20px;"><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Top level item<table role="presentation" style="padding: 0;"><tr><td style="font-family: Helvetica, Arial, sans-serif;"><ul style="margin: 0; padding: 0; list-style-type: disc; margin-inline-start: 20px;"><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Nested item 1</li><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Nested item 2</li></ul></td></tr></table></li><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Another top level item</li></ul></td></tr></table>'
 
         assert remove_nested_list_padding(input_html) == expected_output
 
@@ -1296,21 +1260,6 @@ class TestRemoveNestedListPadding:
             "</div>"
         )
 
-        expected_output = (
-            "<div>"
-            "<p>Some paragraph before</p>"
-            "<ul>"
-            "<li>Item 1"
-            '<table role="presentation" style="padding: 0;">'
-            "<tr><td><ul><li>Nested item</li></ul></td></tr>"
-            "</table>"
-            "</li>"
-            "</ul>"
-            "<p>Some paragraph after</p>"
-            '<table role="presentation" style="padding: 0 0 20px 0;">'
-            "<tr><td>This should keep padding - not nested in li</td></tr>"
-            "</table>"
-            "</div>"
-        )
+        expected_output = '<div><p>Some paragraph before</p><ul><li>Item 1<table role="presentation" style="padding: 0;"><tr><td><ul><li>Nested item</li></ul></td></tr></table></li></ul><p>Some paragraph after</p><table role="presentation" style="padding: 0 0 20px 0;"><tr><td>This should keep padding - not nested in li</td></tr></table></div>'
 
         assert remove_nested_list_padding(input_html) == expected_output

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1184,7 +1184,20 @@ class TestRemoveNestedListPadding:
                     </table>
                     More content
                 </li>""",
-                '<li>\n                    Item with content\n                    <table role="presentation" style="padding: 0;">\n<tr>\n<td>\n<ul>\n<li>Nested item 1</li>\n<li>Nested item 2</li>\n</ul>\n</td>\n</tr>\n</table>\n                    More content\n                </li>',
+                """<li>
+                    Item with content
+                    <table role="presentation" style="padding: 0;">
+                        <tr>
+                            <td>
+                                <ul>
+                                    <li>Nested item 1</li>
+                                    <li>Nested item 2</li>
+                                </ul>
+                            </td>
+                        </tr>
+                    </table>
+                    More content
+                </li>""",
             ),
             # Empty string should return empty string
             ("", ""),
@@ -1237,7 +1250,30 @@ class TestRemoveNestedListPadding:
             "</table>"
         )
 
-        expected_output = '<table role="presentation" style="padding: 0 0 20px 0;"><tr><td style="font-family: Helvetica, Arial, sans-serif;"><ul style="margin: 0; padding: 0; list-style-type: disc; margin-inline-start: 20px;"><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Top level item<table role="presentation" style="padding: 0;"><tr><td style="font-family: Helvetica, Arial, sans-serif;"><ul style="margin: 0; padding: 0; list-style-type: disc; margin-inline-start: 20px;"><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Nested item 1</li><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Nested item 2</li></ul></td></tr></table></li><li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Another top level item</li></ul></td></tr></table>'
+        expected_output = (
+            '<table role="presentation" style="padding: 0 0 20px 0;">'
+            "<tr>"
+            '<td style="font-family: Helvetica, Arial, sans-serif;">'
+            '<ul style="margin: 0; padding: 0; list-style-type: disc; margin-inline-start: 20px;">'
+            '<li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">'
+            "Top level item"
+            '<table role="presentation" style="padding: 0;">'
+            "<tr>"
+            '<td style="font-family: Helvetica, Arial, sans-serif;">'
+            '<ul style="margin: 0; padding: 0; list-style-type: disc; margin-inline-start: 20px;">'
+            '<li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Nested item 1</li>'
+            '<li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Nested item 2</li>'
+            "</ul>"
+            "</td>"
+            "</tr>"
+            "</table>"
+            "</li>"
+            '<li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px; line-height: 25px; color: #0B0C0C; text-align:start;">Another top level item</li>'
+            "</ul>"
+            "</td>"
+            "</tr>"
+            "</table>"
+        )
 
         assert remove_nested_list_padding(input_html) == expected_output
 
@@ -1260,6 +1296,21 @@ class TestRemoveNestedListPadding:
             "</div>"
         )
 
-        expected_output = '<div><p>Some paragraph before</p><ul><li>Item 1<table role="presentation" style="padding: 0;"><tr><td><ul><li>Nested item</li></ul></td></tr></table></li></ul><p>Some paragraph after</p><table role="presentation" style="padding: 0 0 20px 0;"><tr><td>This should keep padding - not nested in li</td></tr></table></div>'
+        expected_output = (
+            "<div>"
+            "<p>Some paragraph before</p>"
+            "<ul>"
+            "<li>Item 1"
+            '<table role="presentation" style="padding: 0;">'
+            "<tr><td><ul><li>Nested item</li></ul></td></tr>"
+            "</table>"
+            "</li>"
+            "</ul>"
+            "<p>Some paragraph after</p>"
+            '<table role="presentation" style="padding: 0 0 20px 0;">'
+            "<tr><td>This should keep padding - not nested in li</td></tr>"
+            "</table>"
+            "</div>"
+        )
 
         assert remove_nested_list_padding(input_html) == expected_output


### PR DESCRIPTION
# Summary | Résumé

Nested list padding fix attempt 3. This PR adds a function to split the html into tokens. This makes the logic a bit easier to follow. 

# Test instructions | Instructions pour tester la modification

1. Check out the api branch here: https://github.com/cds-snc/notification-api/compare/chore/update-utils-2?expand=1 and install with `poetry install`
2. run the app locally
3. send yourself a test message with a nested list, like this:
```
# Prepare for the appointment

Bring with you:
* **Identification:**  -Add types of ID required or delete this bullet-
* **Documents:**  -List all documents needed and link to them if possible-
  * [-document 1-](https://link1.ca)
  * [-document 2-](https://link2.ca)
* **Other:** Add more bullets with other items or delete this bullet-
```
4. verify that you don't see the extra padding in the email

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.