### PR TITLE
Normalize newlines before doing the character count for sms

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -2,4 +2,4 @@ docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
 setuptools==78.1.1 # required for distutils in Python 3.12
-git+https://github.com/cds-snc/notifier-utils.git@53.2.20#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@53.2.21#egg=notifications-utils

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -211,11 +211,14 @@ class SMSMessageTemplate(Template):
         When values are set, placeholders are already replaced via __str__. When no values are
         set, placeholder syntax is stripped before encoding so that placeholder names don't
         inflate the character count or skew Unicode detection.
+
+        normalise_newlines is applied in both paths so that CRLF sequences (\\r\\n) submitted by
+        browsers are counted as a single newline unit, matching what is actually transmitted.
         """
         if self._values:
             # we always want to call SMSMessageTemplate.__str__ regardless of subclass, to avoid any html formatting
             return SMSMessageTemplate.__str__(self)
-        return sms_encode(add_prefix(Field.placeholder_pattern.sub("", self.content.strip()), self.prefix))
+        return normalise_newlines(sms_encode(add_prefix(Field.placeholder_pattern.sub("", self.content.strip()), self.prefix)))
 
     @property
     def content_count(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "53.2.20"
+version = "53.2.21"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_base_template.py
+++ b/tests/test_base_template.py
@@ -78,8 +78,15 @@ def test_extracting_placeholders(template_content, template_subject, expected):
         # should be replaced with a ?
         ("深", None, 1, 1),
         ("'First line.\n", None, 12, 12),
-        ("\t\n\r", None, 0, 0),
-        # variables do not count towards the character count for sms, since they will be replaced
+        ("\t\n\r", None, 0, 0),  # CRLF newlines (\r\n) from browser form submissions must be normalised to \n
+        # before counting, so each line break costs exactly 1 unit (not 2).
+        ("Hello\r\nWorld", None, 11, 11),
+        (
+            "Line1\r\nLine2\r\nLine3",
+            None,
+            17,
+            17,
+        ),  # variables do not count towards the character count for sms, since they will be replaced
         ("((placeholder))", None, 0, 3),
         ("((placeholder))", "Service name", 14, 17),
         ("Foo", "((placeholder))", 20, 20),  # placeholder doesn’t work in service name


### PR DESCRIPTION
# Summary | Résumé

Normalize newlines before doing the character count for sms. This was causing a bug with how we were applying our sms character limit of 612 - newlines were being counted as 2 characters against the limit, but were only costing 1 character when the message was sent. This should fix the issue I was seeing over here: https://github.com/cds-snc/notification-admin/pull/2645

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3043

# Test instructions | Instructions pour tester la modification

1. check out this api branch locally: https://github.com/cds-snc/notification-api/pull/2829
2. run `poetry update notifications-utils` in the api folder
3. run this branch of notification-admin locally: `bug/preview-too-many-chars` from https://github.com/cds-snc/notification-admin/pull/2645
4. create a new sms template and enter 612 characters 
5. add a newline somewhere in the message
6. verify that you see the "1 too many characters" message
7. remove 1 character (not the newline)
8. verify that you do not see the "too many characters" message and that you are able to save the template successfully.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.