### PR TITLE
fix: raise an error when users try to send to unsupported countries

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -2,4 +2,4 @@ docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
 setuptools==78.1.1 # required for distutils in Python 3.12
-git+https://github.com/cds-snc/notifier-utils.git@53.2.23#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@53.2.24#egg=notifications-utils

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -510,8 +510,8 @@ def validate_phone_number(number, column=None, international=False):
         raise InvalidPhoneError("Not a valid country prefix")
 
     # if the prefix is not in our billing rates, then we don't send to it, so we should error here
-    if INTERNATIONAL_BILLING_RATES.get(prefix) is None:
-        raise InvalidPhoneError("Country code {} is not supported".format(prefix))
+    if prefix not in INTERNATIONAL_BILLING_RATES:
+        raise InvalidPhoneError(f"Country code {prefix} is not supported")
 
     return number
 

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -505,8 +505,13 @@ def validate_phone_number(number, column=None, international=False):
     if len(number) < 8:
         raise InvalidPhoneError("Not enough digits")
 
-    if get_international_prefix(number) is None:
+    prefix = get_international_prefix(number)
+    if prefix is None:
         raise InvalidPhoneError("Not a valid country prefix")
+
+    # if the prefix is not in our billing rates, then we don't send to it, so we should error here
+    if INTERNATIONAL_BILLING_RATES.get(prefix) is None:
+        raise InvalidPhoneError("Country code {} is not supported".format(prefix))
 
     return number
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "53.2.23"
+version = "53.2.24"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -206,6 +206,16 @@ def test_get_international_info_raises(phone_number):
     assert str(error.value) == "Not a valid international number"
 
 
+def test_validate_phone_number_raises_for_unsupported_country_code(monkeypatch):
+    # Use a valid international number for which parsing succeeds
+    number = "+249912345678"
+
+    with pytest.raises(InvalidPhoneError) as excinfo:
+        validate_phone_number(number, international=True)
+
+    assert str(excinfo.value) == "Country code 249 is not supported"
+
+
 @pytest.mark.parametrize("phone_number", valid_local_phone_numbers)
 @pytest.mark.parametrize(
     "validator",


### PR DESCRIPTION
# Summary | Résumé
This pull request adds an extra validation step to phone number processing, ensuring that only numbers with supported country codes are accepted. If a phone number's international prefix isn't present in our billing rates, the function now raises an error.

# Test instructions | Instructions pour tester la modification
- [ ] Sending to a unsupported country (you can use country code `249`) fails and does not throw a 500

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.