### PR TITLE
fix: escape href/title attrs and restrict URL schemes in email markdown links

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -2,4 +2,4 @@ docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
 setuptools==78.1.1 # required for distutils in Python 3.12
-git+https://github.com/cds-snc/notifier-utils.git@53.2.24#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@53.2.25#egg=notifications-utils

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -1,3 +1,4 @@
+import html
 import re
 import string
 import urllib
@@ -14,6 +15,30 @@ from notifications_utils.sanitise_text import SanitiseSMS
 from . import email_with_smart_quotes_regex
 
 LINK_STYLE = "word-wrap: break-word; word-break: break-word;"
+
+# Schemes that are safe to render in an ``href`` attribute in email HTML.
+# Anything else (notably ``javascript:`` and ``data:``) is replaced with ``#``
+# to avoid script execution in mail clients that don't sanitise URL schemes.
+ALLOWED_LINK_SCHEMES = frozenset({"http", "https", "mailto", "tel"})
+LINK_SCHEME_REGEX = re.compile(r"^([a-z][a-z0-9+\-.]*):", re.IGNORECASE)
+
+
+def sanitise_link_url(link):
+    """Return ``link`` if it uses a safe URL scheme, otherwise return ``'#'``.
+
+    Links without an explicit scheme (e.g. ``example.com/path``) are passed
+    through unchanged. Whitespace and control characters that some mail clients
+    silently ignore when resolving a URL are stripped before checking the
+    scheme so that e.g. ``" java\\tscript:alert(1)"`` is correctly rejected.
+    """
+    if not link:
+        return "#"
+    stripped = re.sub(r"[\s\x00-\x1f]+", "", link)
+    match = LINK_SCHEME_REGEX.match(stripped)
+    if match and match.group(1).lower() not in ALLOWED_LINK_SCHEMES:
+        return "#"
+    return link
+
 
 OBSCURE_WHITESPACE = (
     "\u180e"  # Mongolian vowel separator
@@ -466,10 +491,12 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
         ).format(text)
 
     def link(self, link, title, content):
-        return ('<a style="{}"{}{}>{}</a>').format(
+        safe_href = html.escape(sanitise_link_url(link), quote=True)
+        title_attr = ' title="{}"'.format(html.escape(title, quote=True)) if title else ""
+        return ('<a style="{}" href="{}"{}>{}</a>').format(
             LINK_STYLE,
-            ' href="{}"'.format(link),
-            ' title="{}"'.format(title) if title else "",
+            safe_href,
+            title_attr,
             content,
         )
 

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -33,10 +33,15 @@ def sanitise_link_url(link):
     """
     if not link:
         return "#"
-    stripped = re.sub(r"[\s\x00-\x1f]+", "", link)
+
+    link = str(link)
+    stripped = strip_and_remove_obscure_whitespace(link)
+    stripped = re.sub(r"[\s\x00-\x1f\x7f]+", "", stripped)
+
     match = LINK_SCHEME_REGEX.match(stripped)
     if match and match.group(1).lower() not in ALLOWED_LINK_SCHEMES:
         return "#"
+
     return link
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "53.2.24"
+version = "53.2.25"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -731,6 +731,62 @@ def test_link_with_title(markdown_function, expected):
 
 
 @pytest.mark.parametrize(
+    "markdown, expected_href, expected_title_attr",
+    (
+        # title with a stray double-quote must not break out of the attribute
+        (
+            '[hi](https://example.com "a\\" onmouseover=\\"alert(1)")',
+            "https://example.com",
+            ' title="a\\&quot; onmouseover=\\&quot;alert(1)"',
+        ),
+        # href with a stray double-quote must not break out of the attribute
+        (
+            '[hi](https://example.com"onmouseover="alert)',
+            "https://example.com&quot;onmouseover=&quot;alert",
+            "",
+        ),
+    ),
+)
+def test_email_link_escapes_attribute_injection(markdown, expected_href, expected_title_attr):
+    rendered = notify_email_markdown(markdown)
+    assert f'href="{expected_href}"{expected_title_attr}>' in rendered
+
+
+@pytest.mark.parametrize(
+    "scheme_url",
+    (
+        "javascript:alert(1)",
+        "JavaScript:alert(1)",
+        " java\tscript:alert(1)",
+        "data:text/html,<script>alert(1)</script>",
+        "vbscript:msgbox(1)",
+        "file:///etc/passwd",
+    ),
+)
+def test_email_link_blocks_unsafe_url_schemes(scheme_url):
+    rendered = notify_email_markdown(f"[click]({scheme_url})")
+    assert 'href="#"' in rendered
+    assert "javascript:" not in rendered.lower()
+    assert "vbscript:" not in rendered.lower()
+    assert "data:" not in rendered.lower()
+
+
+@pytest.mark.parametrize(
+    "safe_url",
+    (
+        "http://example.com",
+        "https://example.com/path?q=1",
+        "mailto:hi@example.com",
+        "tel:+15551234567",
+        "example.com/relative",  # no scheme — passed through
+    ),
+)
+def test_email_link_allows_safe_url_schemes(safe_url):
+    rendered = notify_email_markdown(f"[click]({safe_url})")
+    assert f'href="{safe_url}"' in rendered
+
+
+@pytest.mark.parametrize(
     "markdown_function, expected",
     (
         [notify_letter_preview_markdown, "<p>Strike</p>"],

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -758,6 +758,7 @@ def test_email_link_escapes_attribute_injection(markdown, expected_href, expecte
         "javascript:alert(1)",
         "JavaScript:alert(1)",
         " java\tscript:alert(1)",
+        "java\u200bscript:alert(1)",
         "data:text/html,<script>alert(1)</script>",
         "vbscript:msgbox(1)",
         "file:///etc/passwd",


### PR DESCRIPTION
## What

`NotifyEmailMarkdownRenderer.link()` was interpolating the link URL and title string directly into HTML attribute values without escaping them. Two issues:

1. **Attribute injection** — a crafted title like `"a" onmouseover="alert(1)"` breaks out of the `title=""` attribute and injects arbitrary HTML attributes into the rendered `<a>` tag.
2. **Unsafe URL schemes** — `javascript:`, `data:`, `vbscript:`, `file:` and similar URLs were passed through unchanged, producing script-executable hrefs in some mail clients.

Closes https://github.com/cds-snc/notification-planning/issues/3308

## Testing 

### Reproduce the exploit 
1. in your locally running admin, create a new template with the following content: `[hello](https://example.com "x\" onmouseover=\"alert(1)")`
2. save the template and open the browser console 
3. mouseover the link and observe that you see the following error : 
```
Executing inline event handler violates the following Content Security Policy directive 'script-src 'self ...
```

### Test the fix
1. in your local admin, install utils from this branch with the following: update your pyproject.yaml file with
```
notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", branch = "fix/email-link-xss-attribute-injection" }
```
and run: `poetry update notifications-utils` to install the code from this branch
2. Try the steps above again and observe that there is no error printed to the console