### PR TITLE
fix: thread lang attribute through HTMLEmailTemplate

### DIFF
--- a/notifications_utils/jinja_templates/email/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email/email_template.jinja2
@@ -1,6 +1,6 @@
 {% if complete_html %}
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html lang="en">
+<html lang="{{ lang | default('en', true) }}">
 
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/notifications_utils/jinja_templates/email/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email/email_template.jinja2
@@ -1,6 +1,6 @@
 {% if complete_html %}
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html lang="{{ lang | default('en', true) }}">
+<html lang="{{ lang | default('en', true) | e }}">
 
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -389,6 +389,7 @@ class HTMLEmailTemplate(WithSubjectTemplate):
         allow_html=False,
         alt_text_en=None,
         alt_text_fr=None,
+        lang=None,
     ):
         super().__init__(template, values, jinja_path=jinja_path)
         self.fip_banner_english = fip_banner_english
@@ -403,6 +404,11 @@ class HTMLEmailTemplate(WithSubjectTemplate):
         self.alt_text_en = alt_text_en
         self.alt_text_fr = alt_text_fr
         self.text_direction_rtl = template.get("text_direction_rtl", False)
+        # BCP 47 language tag for the rendered <html lang="..."> attribute. Defaults to
+        # "en" so existing callers keep their current behaviour, but French / bilingual
+        # callers should pass "fr" or "und" so screen readers announce the document
+        # language correctly (WCAG 3.1.1).
+        self.lang = lang or "en"
 
         # set this again to make sure the correct either utils / downstream local jinja is used
         # however, don't set if we are in a test environment (to preserve the above mock)
@@ -447,6 +453,7 @@ class HTMLEmailTemplate(WithSubjectTemplate):
                 "alt_text_en": self.alt_text_en,
                 "alt_text_fr": self.alt_text_fr,
                 "text_direction_rtl": self.text_direction_rtl,
+                "lang": self.lang,
             }
         )
 
@@ -493,6 +500,7 @@ class EmailPreviewTemplate(WithSubjectTemplate):
         alt_text_en=None,
         alt_text_fr=None,
         user_language="en",
+        lang=None,
     ):
         super().__init__(
             template,
@@ -517,6 +525,7 @@ class EmailPreviewTemplate(WithSubjectTemplate):
         self.alt_text_fr = alt_text_fr
         self.user_language = user_language
         self.text_direction_rtl = template.get("text_direction_rtl", False)
+        self.lang = lang or "en"
 
     def __str__(self):
         return Markup(
@@ -544,6 +553,7 @@ class EmailPreviewTemplate(WithSubjectTemplate):
                     "alt_text_en": self.alt_text_en,
                     "alt_text_fr": self.alt_text_fr,
                     "text_direction_rtl": self.text_direction_rtl,
+                    "lang": self.lang,
                 }
             )
         )

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -88,6 +88,41 @@ def test_fip_banner_french(renderer, show_banner):
         assert "canada-logo.png" not in str(email)
 
 
+def test_html_email_lang_defaults_to_english():
+    rendered = str(HTMLEmailTemplate({"content": "hello world", "subject": ""}))
+    assert '<html lang="en">' in rendered
+
+
+@pytest.mark.parametrize(
+    "lang,expected",
+    [
+        ("fr", '<html lang="fr">'),
+        ("fr-CA", '<html lang="fr-CA">'),
+        ("en-CA", '<html lang="en-CA">'),
+        ("und", '<html lang="und">'),
+    ],
+)
+def test_html_email_lang_is_threaded_into_html_tag(lang, expected):
+    rendered = str(HTMLEmailTemplate({"content": "hello world", "subject": ""}, lang=lang))
+    assert expected in rendered
+
+
+def test_html_email_lang_falls_back_to_english_when_none():
+    rendered = str(HTMLEmailTemplate({"content": "hello world", "subject": ""}, lang=None))
+    assert '<html lang="en">' in rendered
+
+
+def test_html_email_bilingual_blocks_get_inline_lang_attributes():
+    # add_language_divs already wraps [[en]]/[[fr]] blocks with lang attributes;
+    # for bilingual content the document-level lang should be set by the caller
+    # (e.g. to "und") so screen readers pick up the lang on the inline divs.
+    bilingual_content = "[[en]]\nHello\n[[/en]]\n[[fr]]\nBonjour\n[[/fr]]"
+    rendered = str(HTMLEmailTemplate({"content": bilingual_content, "subject": ""}, lang="und"))
+    assert '<html lang="und">' in rendered
+    assert '<div lang="en-ca">' in rendered
+    assert '<div lang="fr-ca">' in rendered
+
+
 def test_logo_with_background_colour_shows():
     email = str(
         HTMLEmailTemplate(


### PR DESCRIPTION
# Summary | Résumé

Hardcoded `<html lang="en">` in the email template caused screen readers to
announce French and bilingual emails using English phonemes (WCAG 3.1.1 fail).

- Add optional `lang` kwarg to `HTMLEmailTemplate` and `EmailPreviewTemplate`
  (default `"en"`), threaded into `email_template.jinja2` as
  `<html lang="{{ lang }}">`.
- Callers can pass `"fr"`, `"fr-CA"`, or `"und"` (for bilingual content,
  where `add_language_divs` already emits inline `<div lang="en-ca">` /
  `<div lang="fr-ca">`).
- Tests cover the default, parametrized en/fr/fr-CA/en-CA/und values,
  a `None` fallback, and a bilingual `lang="und"` case.

Companion change in notification-api passes `lang` from `get_html_email_options`.

## Related Issues | Cartes liées

https://github.com/cds-snc/notification-planning/issues/3309

# Test instructions | Instructions pour tester la modification

TBD

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.