### PR TITLE
Add allowed url characters to a safelist

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -2,4 +2,4 @@ docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
 setuptools==78.1.1 # required for distutils in Python 3.12
-git+https://github.com/cds-snc/notifier-utils.git@53.2.27#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@53.2.29#egg=notifications-utils

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -496,7 +496,7 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
         ).format(text)
 
     def link(self, link, title, content):
-        safe_href = urllib.parse.quote(urllib.parse.unquote(sanitise_link_url(link)), safe=":/?#=&;@!$'()*+,~")
+        safe_href = sanitise_link_url(link).replace('"', "%22")
         title_attr = ' title="{}"'.format(html.escape(title, quote=True)) if title else ""
         return ('<a style="{}" href="{}"{}>{}</a>').format(
             LINK_STYLE,

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -496,7 +496,7 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
         ).format(text)
 
     def link(self, link, title, content):
-        safe_href = html.escape(sanitise_link_url(link), quote=True)
+        safe_href = urllib.parse.quote(urllib.parse.unquote(sanitise_link_url(link)), safe=":/?#=&;@!$'()*+,~")
         title_attr = ' title="{}"'.format(html.escape(title, quote=True)) if title else ""
         return ('<a style="{}" href="{}"{}>{}</a>').format(
             LINK_STYLE,

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -496,7 +496,7 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
         ).format(text)
 
     def link(self, link, title, content):
-        safe_href = urllib.parse.quote(urllib.parse.unquote(sanitise_link_url(link)), safe=":/?#=&;@!$'()*+,~")
+        safe_href = urllib.parse.quote(urllib.parse.unquote(sanitise_link_url(link)), safe=":/?#[]@!$&'()*+,;=~")
         title_attr = ' title="{}"'.format(html.escape(title, quote=True)) if title else ""
         return ('<a style="{}" href="{}"{}>{}</a>').format(
             LINK_STYLE,

--- a/poetry.lock
+++ b/poetry.lock
@@ -1735,13 +1735,13 @@ files = [
 
 [[package]]
 name = "werkzeug"
-version = "3.1.8"
+version = "3.1.6"
 description = "The comprehensive WSGI web application library."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50"},
-    {file = "werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44"},
+    {file = "werkzeug-3.1.6-py3-none-any.whl", hash = "sha256:7ddf3357bb9564e407607f988f683d72038551200c704012bb9a4c523d42f131"},
+    {file = "werkzeug-3.1.6.tar.gz", hash = "sha256:210c6bede5a420a913956b4791a7f4d6843a43b6fcee4dfa08a65e93007d0d25"},
 ]
 
 [package.dependencies]
@@ -1753,4 +1753,4 @@ watchdog = ["watchdog (>=2.3)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "~3.12.7"
-content-hash = "9c26a7241854fffbcb029b2dbe57b08d6d03c0dde6746fa5ef5b5227517e1489"
+content-hash = "48292905d08eb15c3700690582b0a6215174a7ced642b9f43555eb9ecccec9e4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ PyYAML = "6.0.3"
 requests = "2.32.3"
 smartypants = "2.0.2"
 statsd = "3.3.0"
-werkzeug = "3.1.8"
+werkzeug = "3.1.6"
 
 [tool.poetry.group.test.dependencies]
 beautifulsoup4 = "^4.12.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "53.2.28"
+version = "53.2.29"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -742,7 +742,7 @@ def test_link_with_title(markdown_function, expected):
         # href with a stray double-quote must not break out of the attribute
         (
             '[hi](https://example.com"onmouseover="alert)',
-            "https://example.com&quot;onmouseover=&quot;alert",
+            "https://example.com%22onmouseover=%22alert",
             "",
         ),
     ),
@@ -777,6 +777,7 @@ def test_email_link_blocks_unsafe_url_schemes(scheme_url):
     (
         "http://example.com",
         "https://example.com/path?q=1",
+        "https://example.com/path?a=1&b=2",  # & must not become &amp;
         "mailto:hi@example.com",
         "tel:+15551234567",
         "example.com/relative",  # no scheme — passed through

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -781,6 +781,14 @@ def test_email_link_blocks_unsafe_url_schemes(scheme_url):
         "mailto:hi@example.com",
         "tel:+15551234567",
         "example.com/relative",  # no scheme — passed through
+        "https://example.com/search?q=hello%20world",
+        "https://example.com/search?q=a+b",
+        "https://example.com/?q=one&two=three",
+        "https://example.com/page#section-1",
+        "https://example.com/café",
+        "https://example.com/a%2Fb",
+        "https://example.com/?next=%2Fadmin%3Fdebug%3D1",
+        "https://example.com/~user/path",
     ),
 )
 def test_email_link_allows_safe_url_schemes(safe_url):


### PR DESCRIPTION
# Summary | Résumé

This PR fixes a bug introduced in https://github.com/cds-snc/notification-utils/pull/414 where `&` characters in urls were being converted to `&amp;`, which was breaking urls.

This was raised in a support request.

## Related Issues | Cartes liées


# Test instructions | Instructions pour tester la modification

1. install this branch locally in notification-api by updating pyproject.toml with this line:
```
notifications-utils = { git = "https://github.com/cds-snc/notifier-utils.git", branch="fix/url-parsing-bug"}
```
and then run `poetry update notifications-utils`
2. create an email template with this in the url: `https://www.google.com/abc?abc=abc&xyz=xyz`
3. sent the email to yourself
4. verify that, when you click the link, `https://www.google.com/abc?abc=abc&xyz=xyz` shows up in the browser address bar

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.