### PR TITLE
Fix/mistune concurrency issues

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -2,4 +2,4 @@ docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
 setuptools==78.1.1 # required for distutils in Python 3.12
-git+https://github.com/cds-snc/notifier-utils.git@53.2.29#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@53.2.30#egg=notifications-utils

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -1,9 +1,10 @@
 import html
 import re
 import string
+import threading
 import urllib
 from itertools import count
-from typing import List
+from typing import Callable, List
 
 import bleach
 import mistune
@@ -619,24 +620,62 @@ class NotifyEmailPreheaderMarkdownRenderer(NotifyPlainTextEmailMarkdownRenderer)
         )
 
 
-notify_email_markdown = mistune.Markdown(
-    renderer=NotifyEmailMarkdownRenderer(),
-    hard_wrap=True,
-    use_xhtml=False,
-)
-notify_plain_text_email_markdown = mistune.Markdown(
-    renderer=NotifyPlainTextEmailMarkdownRenderer(),
-    hard_wrap=True,
-)
-notify_email_preheader_markdown = mistune.Markdown(
-    renderer=NotifyEmailPreheaderMarkdownRenderer(),
-    hard_wrap=True,
-)
-notify_letter_preview_markdown = mistune.Markdown(
-    renderer=NotifyLetterMarkdownPreviewRenderer(),
-    hard_wrap=True,
-    use_xhtml=False,
-)
+_markdown_local = threading.local()
+
+
+def _get_thread_local_markdown(name: str, factory: Callable[[], mistune.Markdown]) -> mistune.Markdown:
+    # Mistune 0.8 markdown instances keep mutable parse state and are not thread-safe.
+    parser = getattr(_markdown_local, name, None)
+    if parser is None:
+        parser = factory()
+        setattr(_markdown_local, name, parser)
+    return parser
+
+
+def _build_notify_email_markdown() -> mistune.Markdown:
+    return mistune.Markdown(
+        renderer=NotifyEmailMarkdownRenderer(),
+        hard_wrap=True,
+        use_xhtml=False,
+    )
+
+
+def _build_notify_plain_text_email_markdown() -> mistune.Markdown:
+    return mistune.Markdown(
+        renderer=NotifyPlainTextEmailMarkdownRenderer(),
+        hard_wrap=True,
+    )
+
+
+def _build_notify_email_preheader_markdown() -> mistune.Markdown:
+    return mistune.Markdown(
+        renderer=NotifyEmailPreheaderMarkdownRenderer(),
+        hard_wrap=True,
+    )
+
+
+def _build_notify_letter_preview_markdown() -> mistune.Markdown:
+    return mistune.Markdown(
+        renderer=NotifyLetterMarkdownPreviewRenderer(),
+        hard_wrap=True,
+        use_xhtml=False,
+    )
+
+
+def notify_email_markdown(text):
+    return _get_thread_local_markdown("notify_email_markdown", _build_notify_email_markdown)(text)
+
+
+def notify_plain_text_email_markdown(text):
+    return _get_thread_local_markdown("notify_plain_text_email_markdown", _build_notify_plain_text_email_markdown)(text)
+
+
+def notify_email_preheader_markdown(text):
+    return _get_thread_local_markdown("notify_email_preheader_markdown", _build_notify_email_preheader_markdown)(text)
+
+
+def notify_letter_preview_markdown(text):
+    return _get_thread_local_markdown("notify_letter_preview_markdown", _build_notify_letter_preview_markdown)(text)
 
 
 def escape_lang_tags(_content: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "53.2.29"
+version = "53.2.30"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,3 +1,5 @@
+from concurrent.futures import ThreadPoolExecutor
+
 import pytest
 from flask import Markup
 from notifications_utils.formatters import (
@@ -12,6 +14,7 @@ from notifications_utils.formatters import (
     nl2li,
     normalise_whitespace,
     notify_email_markdown,
+    notify_email_preheader_markdown,
     notify_letter_preview_markdown,
     notify_plain_text_email_markdown,
     remove_language_divs,
@@ -30,6 +33,33 @@ from notifications_utils.formatters import (
 )
 from notifications_utils.take import Take
 from notifications_utils.template import HTMLEmailTemplate, PlainTextEmailTemplate, SMSMessageTemplate, SMSPreviewTemplate
+
+
+@pytest.mark.parametrize(
+    "markdown_function",
+    [
+        notify_email_markdown,
+        notify_plain_text_email_markdown,
+        notify_email_preheader_markdown,
+        notify_letter_preview_markdown,
+    ],
+)
+def test_markdown_renderers_are_safe_under_concurrency(markdown_function):
+    samples = [
+        "heartbeat ok",
+        "# hi\n\nplain text",
+        "1. a\n2. b\n",
+        "no markdown here",
+        "___\nnext",
+    ]
+
+    def render(i):
+        return markdown_function(samples[i % len(samples)])
+
+    with ThreadPoolExecutor(max_workers=16) as executor:
+        results = list(executor.map(render, range(3000)))
+
+    assert len(results) == 3000
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Summary | Résumé

This pull request updates the Markdown rendering utilities in `notifications_utils/formatters.py` to ensure thread safety and improve reliability when rendering email. The main change is to use thread-local storage for Mistune Markdown parser instances, as Mistune 0.8 is not thread-safe. The pull request also adds tests to verify that the new implementation works correctly under concurrent access.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3385

# Test instructions | Instructions pour tester la modification
- [ ] CI passes

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.