### PR TITLE
fix: update alt text for government logos in email templates

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -2,4 +2,4 @@ docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
 setuptools==78.1.1 # required for distutils in Python 3.12
-git+https://github.com/cds-snc/notifier-utils.git@53.2.29#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@53.2.30#egg=notifications-utils

--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -2,4 +2,4 @@ docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
 setuptools==78.1.1 # required for distutils in Python 3.12
-git+https://github.com/cds-snc/notifier-utils.git@53.2.30#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@53.2.31#egg=notifications-utils

--- a/notifications_utils/jinja_templates/email/_fip_banner.jinja2
+++ b/notifications_utils/jinja_templates/email/_fip_banner.jinja2
@@ -9,7 +9,7 @@
                 {% if fip_banner_english %}
                 <img
                 src="https://assets.notification.canada.ca/gc-logo-en.png?20210531"
-                alt="Government of Canada / Gouvernement du Canada"
+                alt="Government of Canada"
                 height="55"
                 width="286"
                 border="0"
@@ -19,7 +19,7 @@
                 {% if fip_banner_french or brand_name == "canada.ca-fr" %}
                 <img
                 src="https://assets.notification.canada.ca/gc-logo-fr.png?20210531"
-                alt="Gouvernement du Canada / Government of Canada"
+                alt="Gouvernement du Canada"
                 height="55"
                 width="286"
                 border="0"

--- a/notifications_utils/jinja_templates/email/email_preview_template.jinja2
+++ b/notifications_utils/jinja_templates/email/email_preview_template.jinja2
@@ -41,7 +41,7 @@
         <div style="margin: 20px auto 30px auto;">
           <img
             src="https://{{ asset_domain }}/gc-logo-en.png"
-            alt="Government of Canada / Gouvernement du Canada"
+            alt="Government of Canada"
             height="55"
             width="281"
           />
@@ -52,7 +52,7 @@
         <div style="margin: 20px auto 30px auto;">
           <img
             src="https://{{ asset_domain }}/gc-logo-fr.png"
-            alt="Gouvernement du Canada / Government of Canada"
+            alt="Gouvernement du Canada"
             height="55"
             width="281"
           />

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "53.2.30"
+version = "53.2.31"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "53.2.29"
+version = "53.2.30"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -50,8 +50,10 @@ def test_fip_banner_english(renderer, show_banner):
     email = renderer({"content": "hello world", "subject": ""})
     email.fip_banner_english = show_banner
     if show_banner:
-        assert "gc-logo-en.png" in str(email)
-        assert "canada-logo.png" in str(email)
+        rendered_email = str(email)
+        assert "gc-logo-en.png" in rendered_email
+        assert "canada-logo.png" in rendered_email
+        assert 'alt="Government of Canada"' in rendered_email
     else:
         assert "gc-logo-en.png" not in str(email)
         assert "canada-logo.png" not in str(email)
@@ -81,8 +83,10 @@ def test_fip_banner_french(renderer, show_banner):
     email.fip_banner_english = False
     email.fip_banner_french = show_banner
     if show_banner:
-        assert "gc-logo-fr.png" in str(email)
-        assert "canada-logo.png" in str(email)
+        rendered_email = str(email)
+        assert "gc-logo-fr.png" in rendered_email
+        assert "canada-logo.png" in rendered_email
+        assert 'alt="Gouvernement du Canada"' in rendered_email
     else:
         assert "gc-logo-fr.png" not in str(email)
         assert "canada-logo.png" not in str(email)


### PR DESCRIPTION
# Summary | Résumé

This pull request updates the alt text for Government of Canada logos in both English and French email templates to use language-specific descriptions, and updates the related tests to check for the new alt text values.

## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning/issues/3381

# Test instructions | Instructions pour tester la modification
## French-first branding
- Change your branding to french first
- Send yourself an email
- [ ] The branding image contains alt text only in French

## English-first branding
- Change your branding to english first
- Send yourself an email
- [ ] The branding image contains alt text only in English


# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.