### PR TITLE
Updated redis calls to set bounce rate emails

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -2,4 +2,4 @@ docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
 setuptools==78.1.1 # required for distutils in Python 3.12
-git+https://github.com/cds-snc/notifier-utils.git@53.2.31#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@53.2.32#egg=notifications-utils

--- a/notifications_utils/clients/redis/bounce_rate.py
+++ b/notifications_utils/clients/redis/bounce_rate.py
@@ -23,11 +23,11 @@ def seeding_started_key(service_id: str):
 
 
 def bounce_rate_suspension_email_key(service_id: str) -> str:
-    return f"bounce-rate-suspension-email-sent:{service_id}"
+    return f"bounce_rate_suspension_email_sent:{service_id}"
 
 
 def bounce_rate_warning_email_key(service_id: str) -> str:
-    return f"bounce-rate-warning-email-sent:{service_id}"
+    return f"bounce_rate_warning_email_sent:{service_id}"
 
 
 def _current_timestamp_s() -> int:

--- a/notifications_utils/clients/redis/bounce_rate.py
+++ b/notifications_utils/clients/redis/bounce_rate.py
@@ -22,6 +22,14 @@ def seeding_started_key(service_id: str):
     return f"seeding_started:{service_id}"
 
 
+def bounce_rate_suspension_email_key(service_id: str) -> str:
+    return f"bounce-rate-suspension-email-sent:{service_id}"
+
+
+def bounce_rate_warning_email_key(service_id: str) -> str:
+    return f"bounce-rate-warning-email-sent:{service_id}"
+
+
 def _current_timestamp_s() -> int:
     return int(datetime.utcnow().timestamp())
 
@@ -135,3 +143,21 @@ class RedisBounceRate:
             return "critical"
 
         return "warning"
+
+    def set_warning_email_key(self, service_id: str) -> bool:
+        cache_key = bounce_rate_warning_email_key(service_id)
+        if not self._redis_client.active:
+            return False
+
+        if self._redis_client.redis_store.set(cache_key, datetime.utcnow().isoformat(), ex=TWENTY_FOUR_HOURS_IN_SECONDS, nx=True):
+            return True
+        return False
+
+    def set_suspension_email_key(self, service_id: str) -> bool:
+        cache_key = bounce_rate_suspension_email_key(service_id)
+        if not self._redis_client.active:
+            return False
+
+        if self._redis_client.redis_store.set(cache_key, datetime.utcnow().isoformat(), ex=TWENTY_FOUR_HOURS_IN_SECONDS, nx=True):
+            return True
+        return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "53.2.31"
+version = "53.2.32"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_bounce_rate.py
+++ b/tests/test_bounce_rate.py
@@ -219,3 +219,13 @@ class TestRedisBounceRate:
             mocked_service_id, volume_threshold=volume_threshold
         )
         assert bounce_status == expected_status
+
+    def test_set_warning_email_key_only_sets_once(self, better_mocked_bounce_rate_client, mocked_service_id):
+        assert better_mocked_bounce_rate_client.set_warning_email_key(mocked_service_id) is True
+        assert better_mocked_bounce_rate_client.set_warning_email_key(mocked_service_id) is False
+        assert better_mocked_bounce_rate_client.set_warning_email_key(mocked_service_id) is False
+
+    def test_set_suspension_email_key_only_sets_once(self, better_mocked_bounce_rate_client, mocked_service_id):
+        assert better_mocked_bounce_rate_client.set_suspension_email_key(mocked_service_id) is True
+        assert better_mocked_bounce_rate_client.set_suspension_email_key(mocked_service_id) is False
+        assert better_mocked_bounce_rate_client.set_suspension_email_key(mocked_service_id) is False


### PR DESCRIPTION
# Summary | Résumé

We are adding new keys to set whether we are sending bounce rate emails or not. This is functionality to help with that.