### PR TITLE
Redis functions for a sliding window rate limit

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -2,4 +2,4 @@ docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
 setuptools==78.1.1 # required for distutils in Python 3.12
-git+https://github.com/cds-snc/notifier-utils.git@53.2.32#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@53.2.33#egg=notifications-utils

--- a/notifications_utils/clients/redis/sliding_window_rate_limit.py
+++ b/notifications_utils/clients/redis/sliding_window_rate_limit.py
@@ -18,8 +18,8 @@ def report_rate_limit_cache_key(service_id):
 
 def check_and_count_window(redis_client: RedisClient, cache_key: str, window_seconds: int, now: Optional[float] = None) -> int:
     """
-    Remove entries older than window_seconds and return the current count of
-    entries within the window. Returns 0 if Redis is inactive.
+    Remove entries older than or equal to window_seconds and return the current
+    count of entries within the window. Returns 0 if Redis is inactive.
     """
     if not redis_client.active:
         return 0

--- a/notifications_utils/clients/redis/sliding_window_rate_limit.py
+++ b/notifications_utils/clients/redis/sliding_window_rate_limit.py
@@ -7,7 +7,7 @@ accurate counting of requests within it.
 """
 
 from time import time
-from typing import Optional
+from typing import Optional, Tuple
 
 from notifications_utils.clients.redis.redis_client import RedisClient
 
@@ -16,46 +16,46 @@ def report_rate_limit_cache_key(service_id):
     return f"report-rate-limit:{service_id}"
 
 
-def check_and_count_window(redis_client: RedisClient, cache_key: str, window_seconds: int, now: Optional[float] = None) -> int:
+def check_and_record_window_request(
+    redis_client: RedisClient,
+    cache_key: str,
+    limit: int,
+    window_seconds: int,
+    now: Optional[float] = None,
+) -> Tuple[bool, Optional[float]]:
     """
-    Remove entries older than or equal to window_seconds and return the current
-    count of entries within the window. Returns 0 if Redis is inactive.
+    Atomically record a request and check whether the rate limit has been exceeded.
+
+    Uses a single pipeline (zadd -> zremrangebyscore -> zcard -> zrange -> expire)
+    so the record and check happen in the same round-trip, matching the pattern of
+    RedisClient.exceeded_rate_limit.
+
+    Because the entry is added before the count is inspected, a rejected request
+    still occupies a slot in the window.  This prevents concurrent callers from all
+    observing the same pre-add count and all proceeding past the limit.
+
+    Returns:
+        (exceeded, oldest_ts)
+        - exceeded:   True if the count after adding exceeds the limit.
+        - oldest_ts:  Timestamp of the oldest entry when exceeded (used by the
+                      caller to compute reset_at / Retry-After), or None when the
+                      limit is not exceeded or Redis is inactive.
     """
     if not redis_client.active:
-        return 0
+        return False, None
     if now is None:
         now = time()
     window_start = now - window_seconds
     pipe = redis_client.redis_store.pipeline()
+    pipe.zadd(cache_key, {now: now})
     pipe.zremrangebyscore(cache_key, "-inf", window_start)
     pipe.zcard(cache_key)
-    results = pipe.execute()
-    return results[1]
-
-
-def get_window_oldest_entry(redis_client: RedisClient, cache_key: str):
-    """
-    Returns the timestamp of the oldest entry in the sorted set, or None if the
-    set is empty or Redis is inactive.
-    """
-    if not redis_client.active:
-        return None
-    oldest = redis_client.redis_store.zrange(cache_key, 0, 0, withscores=True)
-    if oldest:
-        return oldest[0][1]
-    return None
-
-
-def record_window_request(redis_client: RedisClient, cache_key: str, window_seconds: int, now: Optional[float] = None) -> None:
-    """
-    Record a request in the sliding window sorted set and refresh the key expiry.
-    No-op if Redis is inactive.
-    """
-    if not redis_client.active:
-        return
-    if now is None:
-        now = time()
-    pipe = redis_client.redis_store.pipeline()
-    pipe.zadd(cache_key, {now: now})
+    pipe.zrange(cache_key, 0, 0, withscores=True)
     pipe.expire(cache_key, window_seconds + 60)
-    pipe.execute()
+    results = pipe.execute()
+    count = results[2]
+    if count > limit:
+        oldest_entries = results[3]
+        oldest_ts = oldest_entries[0][1] if oldest_entries else None
+        return True, oldest_ts
+    return False, None

--- a/notifications_utils/clients/redis/sliding_window_rate_limit.py
+++ b/notifications_utils/clients/redis/sliding_window_rate_limit.py
@@ -1,0 +1,60 @@
+"""
+Sliding window rate limiting using Redis sorted sets.
+
+Uses a sorted set where each member is a request timestamp and its score is also
+the timestamp. This allows efficient removal of entries outside the window and
+accurate counting of requests within it.
+"""
+
+from time import time
+
+from notifications_utils.clients.redis.redis_client import RedisClient
+
+
+def report_rate_limit_cache_key(service_id):
+    return f"report-rate-limit:{service_id}"
+
+
+def check_and_count_window(redis_client: RedisClient, cache_key: str, window_seconds: int, now: float = None) -> int:
+    """
+    Remove entries older than window_seconds and return the current count of
+    entries within the window. Returns 0 if Redis is inactive.
+    """
+    if not redis_client.active:
+        return 0
+    if now is None:
+        now = time()
+    window_start = now - window_seconds
+    pipe = redis_client.redis_store.pipeline()
+    pipe.zremrangebyscore(cache_key, "-inf", window_start)
+    pipe.zcard(cache_key)
+    results = pipe.execute()
+    return results[1]
+
+
+def get_window_oldest_entry(redis_client: RedisClient, cache_key: str):
+    """
+    Returns the timestamp of the oldest entry in the sorted set, or None if the
+    set is empty or Redis is inactive.
+    """
+    if not redis_client.active:
+        return None
+    oldest = redis_client.redis_store.zrange(cache_key, 0, 0, withscores=True)
+    if oldest:
+        return oldest[0][1]
+    return None
+
+
+def record_window_request(redis_client: RedisClient, cache_key: str, window_seconds: int, now: float = None) -> None:
+    """
+    Record a request in the sliding window sorted set and refresh the key expiry.
+    No-op if Redis is inactive.
+    """
+    if not redis_client.active:
+        return
+    if now is None:
+        now = time()
+    pipe = redis_client.redis_store.pipeline()
+    pipe.zadd(cache_key, {now: now})
+    pipe.expire(cache_key, window_seconds + 60)
+    pipe.execute()

--- a/notifications_utils/clients/redis/sliding_window_rate_limit.py
+++ b/notifications_utils/clients/redis/sliding_window_rate_limit.py
@@ -7,6 +7,7 @@ accurate counting of requests within it.
 """
 
 from time import time
+from typing import Optional
 
 from notifications_utils.clients.redis.redis_client import RedisClient
 
@@ -15,7 +16,7 @@ def report_rate_limit_cache_key(service_id):
     return f"report-rate-limit:{service_id}"
 
 
-def check_and_count_window(redis_client: RedisClient, cache_key: str, window_seconds: int, now: float = None) -> int:
+def check_and_count_window(redis_client: RedisClient, cache_key: str, window_seconds: int, now: Optional[float] = None) -> int:
     """
     Remove entries older than window_seconds and return the current count of
     entries within the window. Returns 0 if Redis is inactive.
@@ -45,7 +46,7 @@ def get_window_oldest_entry(redis_client: RedisClient, cache_key: str):
     return None
 
 
-def record_window_request(redis_client: RedisClient, cache_key: str, window_seconds: int, now: float = None) -> None:
+def record_window_request(redis_client: RedisClient, cache_key: str, window_seconds: int, now: Optional[float] = None) -> None:
     """
     Record a request in the sliding window sorted set and refresh the key expiry.
     No-op if Redis is inactive.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "53.2.32"
+version = "53.2.33"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_sliding_window_rate_limit.py
+++ b/tests/test_sliding_window_rate_limit.py
@@ -1,0 +1,186 @@
+import uuid
+from time import time
+
+import fakeredis
+import pytest
+from notifications_utils.clients.redis.redis_client import RedisClient
+from notifications_utils.clients.redis.sliding_window_rate_limit import (
+    check_and_count_window,
+    get_window_oldest_entry,
+    record_window_request,
+    report_rate_limit_cache_key,
+)
+
+
+@pytest.fixture
+def fake_redis_client():
+    client = RedisClient()
+    client.redis_store = fakeredis.FakeStrictRedis(version=6)
+    client.active = True
+    return client
+
+
+@pytest.fixture
+def inactive_redis_client():
+    client = RedisClient()
+    client.active = False
+    return client
+
+
+@pytest.fixture
+def cache_key():
+    return report_rate_limit_cache_key(str(uuid.uuid4()))
+
+
+class TestReportRateLimitCacheKey:
+    def test_includes_service_id(self):
+        service_id = "abc-123"
+        assert report_rate_limit_cache_key(service_id) == "report-rate-limit:abc-123"
+
+    def test_different_services_produce_different_keys(self):
+        assert report_rate_limit_cache_key("aaa") != report_rate_limit_cache_key("bbb")
+
+
+class TestCheckAndCountWindow:
+    def test_returns_zero_when_redis_inactive(self, inactive_redis_client, cache_key):
+        assert check_and_count_window(inactive_redis_client, cache_key, 3600) == 0
+
+    def test_returns_zero_for_empty_set(self, fake_redis_client, cache_key):
+        assert check_and_count_window(fake_redis_client, cache_key, 3600) == 0
+
+    def test_counts_entries_within_window(self, fake_redis_client, cache_key):
+        now = time()
+        # Add 3 entries inside the window
+        for i in range(3):
+            ts = now - i * 10
+            fake_redis_client.redis_store.zadd(cache_key, {ts: ts})
+
+        count = check_and_count_window(fake_redis_client, cache_key, 3600, now)
+        assert count == 3
+
+    def test_removes_entries_outside_window(self, fake_redis_client, cache_key):
+        now = time()
+        old_ts = now - 7200  # 2 hours ago — outside a 1-hour window
+        recent_ts = now - 60  # 1 minute ago — inside window
+
+        fake_redis_client.redis_store.zadd(cache_key, {old_ts: old_ts, recent_ts: recent_ts})
+
+        count = check_and_count_window(fake_redis_client, cache_key, 3600, now)
+        assert count == 1
+
+        # Old entry should be gone from the set
+        remaining = fake_redis_client.redis_store.zrange(cache_key, 0, -1, withscores=True)
+        assert len(remaining) == 1
+        assert abs(remaining[0][1] - recent_ts) < 0.001
+
+    def test_entry_exactly_at_window_boundary_is_removed(self, fake_redis_client, cache_key):
+        now = time()
+        boundary_ts = now - 3600  # exactly at the start of a 1-hour window
+        inside_ts = now - 3599
+
+        fake_redis_client.redis_store.zadd(cache_key, {boundary_ts: boundary_ts, inside_ts: inside_ts})
+
+        count = check_and_count_window(fake_redis_client, cache_key, 3600, now)
+        assert count == 1
+
+    def test_uses_current_time_when_now_not_provided(self, fake_redis_client, cache_key):
+        ts = time() - 10
+        fake_redis_client.redis_store.zadd(cache_key, {ts: ts})
+
+        count = check_and_count_window(fake_redis_client, cache_key, 3600)
+        assert count == 1
+
+
+class TestGetWindowOldestEntry:
+    def test_returns_none_when_redis_inactive(self, inactive_redis_client, cache_key):
+        assert get_window_oldest_entry(inactive_redis_client, cache_key) is None
+
+    def test_returns_none_for_empty_set(self, fake_redis_client, cache_key):
+        assert get_window_oldest_entry(fake_redis_client, cache_key) is None
+
+    def test_returns_oldest_timestamp(self, fake_redis_client, cache_key):
+        now = time()
+        oldest = now - 500
+        newer = now - 200
+        newest = now - 50
+
+        fake_redis_client.redis_store.zadd(cache_key, {oldest: oldest, newer: newer, newest: newest})
+
+        result = get_window_oldest_entry(fake_redis_client, cache_key)
+        assert abs(result - oldest) < 0.001
+
+    def test_returns_single_entry(self, fake_redis_client, cache_key):
+        now = time()
+        fake_redis_client.redis_store.zadd(cache_key, {now: now})
+
+        result = get_window_oldest_entry(fake_redis_client, cache_key)
+        assert abs(result - now) < 0.001
+
+
+class TestRecordWindowRequest:
+    def test_no_op_when_redis_inactive(self, inactive_redis_client, cache_key):
+        # Should not raise
+        record_window_request(inactive_redis_client, cache_key, 3600)
+
+    def test_adds_entry_to_sorted_set(self, fake_redis_client, cache_key):
+        now = time()
+        record_window_request(fake_redis_client, cache_key, 3600, now)
+
+        entries = fake_redis_client.redis_store.zrange(cache_key, 0, -1, withscores=True)
+        assert len(entries) == 1
+        assert abs(entries[0][1] - now) < 0.001
+
+    def test_sets_key_expiry(self, fake_redis_client, cache_key):
+        record_window_request(fake_redis_client, cache_key, 3600)
+
+        ttl = fake_redis_client.redis_store.ttl(cache_key)
+        # expiry is window + 60; allow a small margin for test execution time
+        assert 3600 <= ttl <= 3661
+
+    def test_multiple_requests_accumulate(self, fake_redis_client, cache_key):
+        now = time()
+        for i in range(5):
+            record_window_request(fake_redis_client, cache_key, 3600, now + i * 0.001)
+
+        entries = fake_redis_client.redis_store.zrange(cache_key, 0, -1)
+        assert len(entries) == 5
+
+    def test_uses_current_time_when_now_not_provided(self, fake_redis_client, cache_key):
+        before = time()
+        record_window_request(fake_redis_client, cache_key, 3600)
+        after = time()
+
+        entries = fake_redis_client.redis_store.zrange(cache_key, 0, -1, withscores=True)
+        assert len(entries) == 1
+        assert before <= entries[0][1] <= after
+
+
+class TestSlidingWindowIntegration:
+    def test_full_flow_within_limit(self, fake_redis_client, cache_key):
+        now = time()
+        for i in range(9):
+            count = check_and_count_window(fake_redis_client, cache_key, 3600, now)
+            assert count < 10
+            record_window_request(fake_redis_client, cache_key, 3600, now + i * 0.001)
+
+    def test_full_flow_at_limit(self, fake_redis_client, cache_key):
+        now = time()
+        # Pre-fill with 10 entries
+        for i in range(10):
+            fake_redis_client.redis_store.zadd(cache_key, {now - i: now - i})
+
+        count = check_and_count_window(fake_redis_client, cache_key, 3600, now)
+        assert count == 10
+
+    def test_expired_entries_bring_count_below_limit(self, fake_redis_client, cache_key):
+        now = time()
+        # 8 old entries outside window + 5 recent entries inside window
+        for i in range(8):
+            old_ts = now - 7200 - i
+            fake_redis_client.redis_store.zadd(cache_key, {old_ts: old_ts})
+        for i in range(5):
+            recent_ts = now - i * 10
+            fake_redis_client.redis_store.zadd(cache_key, {recent_ts: recent_ts})
+
+        count = check_and_count_window(fake_redis_client, cache_key, 3600, now)
+        assert count == 5

--- a/tests/test_sliding_window_rate_limit.py
+++ b/tests/test_sliding_window_rate_limit.py
@@ -5,9 +5,7 @@ import fakeredis
 import pytest
 from notifications_utils.clients.redis.redis_client import RedisClient
 from notifications_utils.clients.redis.sliding_window_rate_limit import (
-    check_and_count_window,
-    get_window_oldest_entry,
-    record_window_request,
+    check_and_record_window_request,
     report_rate_limit_cache_key,
 )
 
@@ -41,146 +39,102 @@ class TestReportRateLimitCacheKey:
         assert report_rate_limit_cache_key("aaa") != report_rate_limit_cache_key("bbb")
 
 
-class TestCheckAndCountWindow:
-    def test_returns_zero_when_redis_inactive(self, inactive_redis_client, cache_key):
-        assert check_and_count_window(inactive_redis_client, cache_key, 3600) == 0
+class TestCheckAndRecordWindowRequest:
+    def test_returns_not_exceeded_when_redis_inactive(self, inactive_redis_client, cache_key):
+        exceeded, oldest_ts = check_and_record_window_request(inactive_redis_client, cache_key, 10, 3600)
+        assert exceeded is False
+        assert oldest_ts is None
 
-    def test_returns_zero_for_empty_set(self, fake_redis_client, cache_key):
-        assert check_and_count_window(fake_redis_client, cache_key, 3600) == 0
-
-    def test_counts_entries_within_window(self, fake_redis_client, cache_key):
+    def test_not_exceeded_below_limit(self, fake_redis_client, cache_key):
         now = time()
-        # Add 3 entries inside the window
-        for i in range(3):
-            ts = now - i * 10
-            fake_redis_client.redis_store.zadd(cache_key, {ts: ts})
+        for i in range(9):
+            exceeded, oldest_ts = check_and_record_window_request(fake_redis_client, cache_key, 10, 3600, now + i * 0.001)
+            assert exceeded is False
+            assert oldest_ts is None
 
-        count = check_and_count_window(fake_redis_client, cache_key, 3600, now)
-        assert count == 3
-
-    def test_removes_entries_outside_window(self, fake_redis_client, cache_key):
+    def test_not_exceeded_at_exact_limit(self, fake_redis_client, cache_key):
         now = time()
-        old_ts = now - 7200  # 2 hours ago — outside a 1-hour window
-        recent_ts = now - 60  # 1 minute ago — inside window
+        # Pre-fill 9 entries, then add the 10th — count reaches limit but does not exceed
+        for i in range(9):
+            fake_redis_client.redis_store.zadd(cache_key, {now - i: now - i})
 
-        fake_redis_client.redis_store.zadd(cache_key, {old_ts: old_ts, recent_ts: recent_ts})
+        exceeded, oldest_ts = check_and_record_window_request(fake_redis_client, cache_key, 10, 3600, now)
+        assert exceeded is False
+        assert oldest_ts is None
 
-        count = check_and_count_window(fake_redis_client, cache_key, 3600, now)
-        assert count == 1
-
-        # Old entry should be gone from the set
-        remaining = fake_redis_client.redis_store.zrange(cache_key, 0, -1, withscores=True)
-        assert len(remaining) == 1
-        assert abs(remaining[0][1] - recent_ts) < 0.001
-
-    def test_entry_exactly_at_window_boundary_is_removed(self, fake_redis_client, cache_key):
+    def test_exceeded_when_over_limit(self, fake_redis_client, cache_key):
         now = time()
-        boundary_ts = now - 3600  # exactly at the start of a 1-hour window
-        inside_ts = now - 3599
+        # Pre-fill 10 entries so the next add pushes count to 11.
+        # Use now - (i+1) so no member equals `now` (sorted sets deduplicate by member).
+        for i in range(10):
+            fake_redis_client.redis_store.zadd(cache_key, {now - (i + 1): now - (i + 1)})
 
-        fake_redis_client.redis_store.zadd(cache_key, {boundary_ts: boundary_ts, inside_ts: inside_ts})
+        exceeded, oldest_ts = check_and_record_window_request(fake_redis_client, cache_key, 10, 3600, now)
+        assert exceeded is True
 
-        count = check_and_count_window(fake_redis_client, cache_key, 3600, now)
-        assert count == 1
-
-    def test_uses_current_time_when_now_not_provided(self, fake_redis_client, cache_key):
-        ts = time() - 10
-        fake_redis_client.redis_store.zadd(cache_key, {ts: ts})
-
-        count = check_and_count_window(fake_redis_client, cache_key, 3600)
-        assert count == 1
-
-
-class TestGetWindowOldestEntry:
-    def test_returns_none_when_redis_inactive(self, inactive_redis_client, cache_key):
-        assert get_window_oldest_entry(inactive_redis_client, cache_key) is None
-
-    def test_returns_none_for_empty_set(self, fake_redis_client, cache_key):
-        assert get_window_oldest_entry(fake_redis_client, cache_key) is None
-
-    def test_returns_oldest_timestamp(self, fake_redis_client, cache_key):
+    def test_oldest_ts_is_populated_when_exceeded(self, fake_redis_client, cache_key):
         now = time()
-        oldest = now - 500
-        newer = now - 200
-        newest = now - 50
+        oldest = now - 100
+        for i in range(9):
+            fake_redis_client.redis_store.zadd(cache_key, {oldest - i: oldest - i})
+        # one more entry puts us to 10 before the new add
+        fake_redis_client.redis_store.zadd(cache_key, {now - 50: now - 50})
 
-        fake_redis_client.redis_store.zadd(cache_key, {oldest: oldest, newer: newer, newest: newest})
+        exceeded, oldest_ts = check_and_record_window_request(fake_redis_client, cache_key, 10, 3600, now)
+        assert exceeded is True
+        # oldest_ts should be the smallest score still in the window
+        assert oldest_ts is not None
+        assert oldest_ts <= oldest
 
-        result = get_window_oldest_entry(fake_redis_client, cache_key)
-        assert abs(result - oldest) < 0.001
-
-    def test_returns_single_entry(self, fake_redis_client, cache_key):
+    def test_expired_entries_are_trimmed_before_counting(self, fake_redis_client, cache_key):
         now = time()
-        fake_redis_client.redis_store.zadd(cache_key, {now: now})
+        # 8 old entries outside the window + 1 inside = 9 total before add
+        for i in range(8):
+            old_ts = now - 7200 - i
+            fake_redis_client.redis_store.zadd(cache_key, {old_ts: old_ts})
+        fake_redis_client.redis_store.zadd(cache_key, {now - 10: now - 10})
 
-        result = get_window_oldest_entry(fake_redis_client, cache_key)
-        assert abs(result - now) < 0.001
+        # After trim, only 1 valid entry + the new one = count 2, not exceeded
+        exceeded, oldest_ts = check_and_record_window_request(fake_redis_client, cache_key, 10, 3600, now)
+        assert exceeded is False
 
-
-class TestRecordWindowRequest:
-    def test_no_op_when_redis_inactive(self, inactive_redis_client, cache_key):
-        # Should not raise
-        record_window_request(inactive_redis_client, cache_key, 3600)
-
-    def test_adds_entry_to_sorted_set(self, fake_redis_client, cache_key):
+    def test_entry_at_window_boundary_is_trimmed(self, fake_redis_client, cache_key):
         now = time()
-        record_window_request(fake_redis_client, cache_key, 3600, now)
+        boundary_ts = now - 3600  # exactly at window start — should be removed
+        for i in range(10):
+            fake_redis_client.redis_store.zadd(cache_key, {boundary_ts - i: boundary_ts - i})
 
-        entries = fake_redis_client.redis_store.zrange(cache_key, 0, -1, withscores=True)
-        assert len(entries) == 1
-        assert abs(entries[0][1] - now) < 0.001
+        # All 10 pre-filled entries fall outside or at the boundary; only the new
+        # entry remains after trim, so count == 1 and limit is not exceeded
+        exceeded, _ = check_and_record_window_request(fake_redis_client, cache_key, 10, 3600, now)
+        assert exceeded is False
 
     def test_sets_key_expiry(self, fake_redis_client, cache_key):
-        record_window_request(fake_redis_client, cache_key, 3600)
+        check_and_record_window_request(fake_redis_client, cache_key, 10, 3600)
 
         ttl = fake_redis_client.redis_store.ttl(cache_key)
-        # expiry is window + 60; allow a small margin for test execution time
+        # expiry is window_seconds + 60; allow small margin for test execution time
         assert 3600 <= ttl <= 3661
 
-    def test_multiple_requests_accumulate(self, fake_redis_client, cache_key):
+    def test_rejected_request_occupies_a_slot(self, fake_redis_client, cache_key):
         now = time()
-        for i in range(5):
-            record_window_request(fake_redis_client, cache_key, 3600, now + i * 0.001)
+        # Fill to the brim so the next add exceeds the limit.
+        # Use now - (i+1) so no member equals `now`.
+        for i in range(10):
+            fake_redis_client.redis_store.zadd(cache_key, {now - (i + 1): now - (i + 1)})
 
-        entries = fake_redis_client.redis_store.zrange(cache_key, 0, -1)
-        assert len(entries) == 5
+        exceeded, _ = check_and_record_window_request(fake_redis_client, cache_key, 10, 3600, now)
+        assert exceeded is True
+
+        # The rejected entry was still added; set now has 11 members
+        count = fake_redis_client.redis_store.zcard(cache_key)
+        assert count == 11
 
     def test_uses_current_time_when_now_not_provided(self, fake_redis_client, cache_key):
         before = time()
-        record_window_request(fake_redis_client, cache_key, 3600)
+        check_and_record_window_request(fake_redis_client, cache_key, 10, 3600)
         after = time()
 
         entries = fake_redis_client.redis_store.zrange(cache_key, 0, -1, withscores=True)
         assert len(entries) == 1
         assert before <= entries[0][1] <= after
-
-
-class TestSlidingWindowIntegration:
-    def test_full_flow_within_limit(self, fake_redis_client, cache_key):
-        now = time()
-        for i in range(9):
-            count = check_and_count_window(fake_redis_client, cache_key, 3600, now)
-            assert count < 10
-            record_window_request(fake_redis_client, cache_key, 3600, now + i * 0.001)
-
-    def test_full_flow_at_limit(self, fake_redis_client, cache_key):
-        now = time()
-        # Pre-fill with 10 entries
-        for i in range(10):
-            fake_redis_client.redis_store.zadd(cache_key, {now - i: now - i})
-
-        count = check_and_count_window(fake_redis_client, cache_key, 3600, now)
-        assert count == 10
-
-    def test_expired_entries_bring_count_below_limit(self, fake_redis_client, cache_key):
-        now = time()
-        # 8 old entries outside window + 5 recent entries inside window
-        for i in range(8):
-            old_ts = now - 7200 - i
-            fake_redis_client.redis_store.zadd(cache_key, {old_ts: old_ts})
-        for i in range(5):
-            recent_ts = now - i * 10
-            fake_redis_client.redis_store.zadd(cache_key, {recent_ts: recent_ts})
-
-        count = check_and_count_window(fake_redis_client, cache_key, 3600, now)
-        assert count == 5

--- a/tests/test_sliding_window_rate_limit.py
+++ b/tests/test_sliding_window_rate_limit.py
@@ -15,7 +15,7 @@ from notifications_utils.clients.redis.sliding_window_rate_limit import (
 @pytest.fixture
 def fake_redis_client():
     client = RedisClient()
-    client.redis_store = fakeredis.FakeStrictRedis(version=6)
+    client.redis_store = fakeredis.FakeStrictRedis(version=6)  # type: ignore
     client.active = True
     return client
 


### PR DESCRIPTION
# Summary | Résumé

This is for the reports api rate limit https://github.com/cds-snc/notification-api/pull/2975

## Related Issues | Cartes liées

- https://github.com/cds-snc/notification-planning/issues/3406

# Test instructions | Instructions pour tester la modification

Testing instructions over here: https://github.com/cds-snc/notification-api/pull/2975

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.