### PR TITLE
Better parallel_process_iterable thread safety

### DIFF
--- a/.github/actions/waffles/requirements.txt
+++ b/.github/actions/waffles/requirements.txt
@@ -2,4 +2,4 @@ docopt==0.6.2
 Flask==2.3.3
 markupsafe==2.1.5
 setuptools==78.1.1 # required for distutils in Python 3.12
-git+https://github.com/cds-snc/notifier-utils.git@53.2.32#egg=notifications-utils
+git+https://github.com/cds-snc/notifier-utils.git@53.2.34#egg=notifications-utils

--- a/notifications_utils/decorators.py
+++ b/notifications_utils/decorators.py
@@ -44,17 +44,17 @@ def parallel_process_iterable(
         def wrapper(*args, **kwargs):
             data = args[0]
             data_size = len(data)
-            nonlocal chunk_size, max_workers
-            chunk_size, max_workers = control_chunk_and_worker_size(data_size, chunk_size, max_workers)
+            # Compute execution settings per invocation to avoid shared mutable closure state.
+            effective_chunk_size, effective_max_workers = control_chunk_and_worker_size(data_size, chunk_size, max_workers)
 
             def process_chunk(chunk):
                 return func(chunk, *args[1:])
 
             # Execute in parallel
-            with ThreadPoolExecutor(max_workers=max_workers) as executor:
-                futures = [executor.submit(process_chunk, chunk) for chunk in chunk_iterable(data, chunk_size)]
+            with ThreadPoolExecutor(max_workers=effective_max_workers) as executor:
+                futures = [executor.submit(process_chunk, chunk) for chunk in chunk_iterable(data, effective_chunk_size)]
                 current_app.logger.info(
-                    f"Beginning parallel processing of {data_size} items in {len(futures)} chunks for {func.__name__} across {max_workers} workers."
+                    f"Beginning parallel processing of {data_size} items in {len(futures)} chunks for {func.__name__} across {effective_max_workers} workers."
                 )
                 # Combine results
                 results = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "notifications-utils"
-version = "53.2.32"
+version = "53.2.34"
 description = "Shared python code for Notification - Provides logging utils etc."
 authors = ["Canadian Digital Service"]
 license = "MIT license"

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,3 +1,5 @@
+from concurrent.futures import ThreadPoolExecutor
+
 import pytest
 from notifications_utils.decorators import control_chunk_and_worker_size, parallel_process_iterable, requires_feature
 
@@ -119,3 +121,59 @@ def test_parallel_process_iterable_continues_on_break_condition_exceptions_if_no
 def test_control_chunk_and_worker_size_scales_workers_down_when_chunk_size_exceeds_threshold(mocker):
     mocker.patch("multiprocessing.cpu_count", return_value=28)  # m5.large has 28 cores
     assert control_chunk_and_worker_size(300000) == (10000, 14)  # (chunk_size, worker_count)
+
+
+def test_parallel_process_iterable_does_not_persist_computed_values_between_calls(app, mocker):
+    calls = []
+
+    def fake_control_chunk_and_worker_size(data_size, chunk_size, max_workers):
+        calls.append((data_size, chunk_size, max_workers))
+        return data_size, 1
+
+    mocker.patch("notifications_utils.decorators.control_chunk_and_worker_size", side_effect=fake_control_chunk_and_worker_size)
+
+    @parallel_process_iterable()
+    def process_chunk_for_closure_isolation(chunk):
+        return list(chunk)
+
+    process_chunk_for_closure_isolation([1, 2, 3, 4, 5])
+    process_chunk_for_closure_isolation([1, 2, 3])
+
+    # Both calls should pass the original decorator arguments to the control helper.
+    assert calls == [(5, 10000, None), (3, 10000, None)]
+
+
+def test_parallel_process_iterable_uses_per_invocation_settings_under_concurrency(app, mocker):
+    def fake_control_chunk_and_worker_size(data_size, chunk_size, max_workers):
+        if data_size == 1200:
+            return 300, 1
+        if data_size == 2400:
+            return 800, 1
+        raise AssertionError(f"Unexpected data_size in test: {data_size}")
+
+    mocker.patch("notifications_utils.decorators.control_chunk_and_worker_size", side_effect=fake_control_chunk_and_worker_size)
+
+    @parallel_process_iterable()
+    def process_chunk_for_thread_safety(chunk):
+        return list(chunk)
+
+    def run(data):
+        with app.app_context():
+            return process_chunk_for_thread_safety(data)
+
+    data_small = list(range(1200))
+    data_large = list(range(2400))
+
+    # Repeat concurrent calls to increase race detection sensitivity.
+    for _ in range(200):
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            future_small = executor.submit(run, data_small)
+            future_large = executor.submit(run, data_large)
+
+            results_small = future_small.result()
+            results_large = future_large.result()
+
+        assert len(results_small) == 4
+        assert all(len(chunk) <= 300 for chunk in results_small)
+        assert len(results_large) == 3
+        assert all(len(chunk) <= 800 for chunk in results_large)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,3 +1,4 @@
+import threading
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -144,7 +145,14 @@ def test_parallel_process_iterable_does_not_persist_computed_values_between_call
 
 
 def test_parallel_process_iterable_uses_per_invocation_settings_under_concurrency(app, mocker):
+    barrier = None
+
     def fake_control_chunk_and_worker_size(data_size, chunk_size, max_workers):
+        nonlocal barrier
+        # Force both concurrent invocations to overlap deterministically in this helper.
+        if barrier is not None:
+            barrier.wait(timeout=2)
+
         if data_size == 1200:
             return 300, 1
         if data_size == 2400:
@@ -164,9 +172,10 @@ def test_parallel_process_iterable_uses_per_invocation_settings_under_concurrenc
     data_small = list(range(1200))
     data_large = list(range(2400))
 
-    # Repeat concurrent calls to increase race detection sensitivity.
-    for _ in range(200):
-        with ThreadPoolExecutor(max_workers=2) as executor:
+    # Reuse one executor and run fewer deterministic overlap checks to keep runtime low.
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        for _ in range(25):
+            barrier = threading.Barrier(2)
             future_small = executor.submit(run, data_small)
             future_large = executor.submit(run, data_large)
 


### PR DESCRIPTION
# Summary | Résumé

This PR improves the thread-safety of our `parallel_process_iterable` decorator. The primary change is to the `chunk_size` and `max_worker` variables, ensuring that they are scoped to and calculated **per-invocation**  as opposed to being shared mutable objects.

In addition to being thread-safe, these computed variables should be more accurately calculated, as concurrent calculations will no longer overwrite one another leading to potentially inefficient parallelization when processing iterables.


## Related Issues | Cartes liées

* https://github.com/cds-snc/notification-planning-core/issues/909

# Test instructions | Instructions pour tester la modification
- [ ] CI is passing
- [ ] Batch saving receipts is monitored in staging, no regressions in performance or resource usage.

# Release Instructions | Instructions pour le déploiement

None.

# Reviewer checklist | Liste de vérification du réviseur

- [ ] This PR does not break existing functionality.
- [ ] This PR does not violate GCNotify's privacy policies.
- [ ] This PR does not raise new security concerns. Refer to our GC Notify Risk Register document on our Google drive.
- [ ] This PR does not significantly alter performance.
- [ ] Additional required documentation resulting of these changes is covered (such as the README, setup instructions, a related ADR or the technical documentation).

> ⚠ If boxes cannot be checked off before merging the PR, they should be moved to the "Release Instructions" section with appropriate steps required to verify before release. For example, changes to celery code may require tests on staging to verify that performance has not been affected.