### PR TITLE
security: pin GitHub Actions to SHA

### DIFF
--- a/.github/actions/waffles/Dockerfile
+++ b/.github/actions/waffles/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM python:3.12@sha256:e5931cdb4a8cec0ad083277c16a39114f14123b8b6c858c8c9689b677789975c
+FROM python:3.12
 
 RUN apt update
 RUN apt install -y python3-pip python3 git libmagic-dev

--- a/.github/actions/waffles/Dockerfile
+++ b/.github/actions/waffles/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM python:3.12
+FROM python:3.12@sha256:e5931cdb4a8cec0ad083277c16a39114f14123b8b6c858c8c9689b677789975c
 
 RUN apt update
 RUN apt install -y python3-pip python3 git libmagic-dev

--- a/.github/workflows/backstage-catalog-helper.yml
+++ b/.github/workflows/backstage-catalog-helper.yml
@@ -11,24 +11,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Audit DNS requests
-        uses: cds-snc/dns-proxy-action@f0796e7f3d6bec5d40aecb0321ed8012f5602f84 # v1.0.2
+        uses: cds-snc/dns-proxy-action@f0796e7f3d6bec5d40aecb0321ed8012f5602f84 # main as of 2026-02-09
         env:
           DNS_PROXY_FORWARDTOSENTINEL: "true"
           DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
           DNS_PROXY_LOGANALYTICSSHAREDKEY: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
       - name: Checkout Actions
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Run Backstage Catalog Info Helper
-        uses: cds-snc/backstage-catalog-info-helper-action@cc75afc29a0ade6c41400132ff9e1222f8916ba6 # v0.3.1
+        uses: cds-snc/backstage-catalog-info-helper-action@cc75afc29a0ade6c41400132ff9e1222f8916ba6 # main as of 2025-06-05
         with:
           github_app_id: ${{ secrets.SRE_BOT_RW_APP_ID }}
           github_app_private_key: ${{ secrets.SRE_BOT_RW_PRIVATE_KEY }}
           github_organization: cds-snc
       - name: impersonate Read/Write GH App
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         id: generate_token
         with:
           app_id: ${{ secrets.SRE_BOT_RW_APP_ID }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set up Python 3.12
       uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2.3.4

--- a/.github/workflows/export_github_data.yml
+++ b/.github/workflows/export_github_data.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Audit DNS requests
-        uses: cds-snc/dns-proxy-action@2aee21aebfddefac5839497648a36a9f84342d8b
+        uses: cds-snc/dns-proxy-action@2aee21aebfddefac5839497648a36a9f84342d8b # main as of 2025-06-16
         env:
           DNS_PROXY_FORWARDTOSENTINEL: "true"
           DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
@@ -29,7 +29,7 @@ jobs:
           role-session-name: GithubDataExport
           aws-region: ca-central-1
       - name: Export Data
-        uses: cds-snc/github-repository-metadata-exporter@fe65ed89fcabde7d0ea0d1fe022ea85825b6f6f8
+        uses: cds-snc/github-repository-metadata-exporter@fe65ed89fcabde7d0ea0d1fe022ea85825b6f6f8 # main as of 2026-03-09
         with:
           github-app-id: ${{ secrets.SRE_BOT_RO_APP_ID }}
           github-app-installation-id: ${{ secrets.SRE_BOT_RO_INSTALLATION_ID }}

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: "Audit DNS requests"
-        uses: cds-snc/dns-proxy-action@f0796e7f3d6bec5d40aecb0321ed8012f5602f84 # v1.0.2
+        uses: cds-snc/dns-proxy-action@f0796e7f3d6bec5d40aecb0321ed8012f5602f84 # main as of 2026-02-09
         env:
           DNS_PROXY_FORWARDTOSENTINEL: "true"
           DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
@@ -35,7 +35,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@169c9b9248e36d400bebded8160c7fe2cbbc7762
+        uses: ossf/scorecard-action@169c9b9248e36d400bebded8160c7fe2cbbc7762 # main as of 2025-03-08
         with:
           results_file: ossf-results.json
           results_format: json
@@ -49,7 +49,7 @@ jobs:
           jq -c '. + {"metadata_owner": "'$OWNER'", "metadata_repo": "'$REPO'", "metadata_query": "ossf"}' ossf-results.json > ossf-results-modified.json
 
       - name: "Post results to Sentinel"
-        uses: cds-snc/sentinel-forward-data-action@2b0831903177e4ba07c850c71ab2645f72cab269
+        uses: cds-snc/sentinel-forward-data-action@2b0831903177e4ba07c850c71ab2645f72cab269 # main as of 2026-05-21
         with:
           file_name: ossf-results-modified.json
           dce_endpoint: ${{ secrets.SENTINEL_DCE_ENDPOINT }}

--- a/.github/workflows/s3-backup.yml
+++ b/.github/workflows/s3-backup.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Audit DNS requests
-      uses: cds-snc/dns-proxy-action@f0796e7f3d6bec5d40aecb0321ed8012f5602f84 # v1.0.2
+      uses: cds-snc/dns-proxy-action@f0796e7f3d6bec5d40aecb0321ed8012f5602f84 # main as of 2026-02-09
       env:
         DNS_PROXY_FORWARDTOSENTINEL: "true"
         DNS_PROXY_LOGANALYTICSWORKSPACEID: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}

--- a/.github/workflows/seekret.yaml
+++ b/.github/workflows/seekret.yaml
@@ -5,6 +5,6 @@ jobs:
     name: docker://cdssnc/seekret-github-action
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@main
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - name: docker://cdssnc/seekret-github-action
       uses: docker://cdssnc/seekret-github-action@sha256:0aee6df949373ef6df26d35f6207b56f897ddd1caa030646d7421b0afb717665


### PR DESCRIPTION
## What
Part of the org-wide GitHub Actions SHA-pinning initiative.

- Pin `actions/checkout@main` (mutable ref) to a fixed SHA in `ci.yaml` and `seekret.yaml`
- Add missing `# vX.Y.Z` version comments for already-SHA-pinned actions in `backstage-catalog-helper.yml` (`actions/checkout`, `tibdex/github-app-token`)
- Add missing version comments in `export_github_data.yml` and `ossf-scorecard.yml` for pinned SHAs that don't correspond to a tagged release (`# main as of <date>`)
- Correct two existing-but-wrong version comments, found by verifying every SHA against `gh api repos/{owner}/{repo}/tags`:
  - `cds-snc/dns-proxy-action` was labeled `# v1.0.2` but the pinned SHA is actually 2 commits ahead of that tag (untagged, on `main`)
  - `cds-snc/backstage-catalog-info-helper-action` was labeled `# v0.3.1` but the pinned SHA has diverged from that tag entirely

`renovate.json` was left untouched — it already extends `local>cds-snc/renovate-config`, which covers GitHub Actions digest pinning.

## Why
Reduce supply-chain risk from mutable tags/branches in CI workflows and ensure version comments accurately reflect what's pinned.